### PR TITLE
renamed path to volume throughout

### DIFF
--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -331,7 +331,7 @@ pub struct Resources {
     pub cpu: CPU,
     pub memory: Memory,
     pub gpu: GPU,
-    pub paths: Vec<Path>,
+    pub volumes: Vec<Volume>,
 }
 impl Resources {
     fn to_resource_requirements(&self) -> core::ResourceRequirements {
@@ -359,7 +359,7 @@ impl Default for Resources {
             gpu: GPU {
                 required: "0".into(),
             },
-            paths: Vec::new(),
+            volumes: Vec::new(),
         }
     }
 }
@@ -391,20 +391,37 @@ pub struct GPU {
     pub required: String,
 }
 
-/// Path describes a path that is attached to a Container.
+/// Volume describes a path that is attached to a Container.
 ///
 /// It specifies not only the location, but also the requirements.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct Path {
+pub struct Volume {
     pub name: String,
-    pub path: String,
+    pub mount_path: String,
 
     #[serde(default)]
     pub access_mode: AccessMode,
 
     #[serde(default)]
     pub sharing_policy: SharingPolicy,
+    pub disk: Option<Disk>,
+}
+
+// Disk describes the disk requirements for backing a Volume.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct Disk {
+    required: String,
+    ephemeral: bool,
+}
+impl Default for Disk {
+    fn default() -> Disk {
+        Disk {
+            required: "1G".into(),
+            ephemeral: false,
+        }
+    }
 }
 
 /// AccessMode defines the access modes for file systems.

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -111,14 +111,14 @@ fn test_container_deserialize() {
                         "memory": {
                             "required": "2G"
                         },
-                        "paths": [
+                        "volumes": [
                             {
                                 "name": "first",
-                                "path": "/path/to/first"
+                                "mountPath": "/path/to/first"
                             },
                             {
                                 "name": "second",
-                                "path": "/path/to/second",
+                                "mountPath": "/path/to/second",
                                 "accessMode": "RO",
                                 "sharingPolicy": "Shared"
                             }
@@ -156,16 +156,16 @@ fn test_container_deserialize() {
     assert_eq!("2G", res.memory.required);
     assert_eq!("1", res.cpu.required);
 
-    let path1 = res.paths.get(0).unwrap();
-    let path2 = res.paths.get(1).unwrap();
+    let path1 = res.volumes.get(0).unwrap();
+    let path2 = res.volumes.get(1).unwrap();
 
     assert_eq!("first", path1.name);
-    assert_eq!("/path/to/first", path1.path);
+    assert_eq!("/path/to/first", path1.mount_path);
     assert_eq!(SharingPolicy::Exclusive, path1.sharing_policy);
     assert_eq!(AccessMode::RW, path1.access_mode);
 
     assert_eq!("second", path2.name);
-    assert_eq!("/path/to/second", path2.path);
+    assert_eq!("/path/to/second", path2.mount_path);
     assert_eq!(SharingPolicy::Shared, path2.sharing_policy);
     assert_eq!(AccessMode::RO, path2.access_mode);
 }


### PR DESCRIPTION
This brings the naming and properties for `container.requirements` back into line with the current version of the spec.