### PR TITLE
Add Helm chart and Dockerfile for scylla

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+_scratch/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.36 AS builder
+WORKDIR /usr/src/scylla
+COPY ./src ./src
+COPY Cargo.toml .
+COPY Cargo.lock .
+RUN cargo build --release
+RUN ls -lah ./target/release
+
+FROM debian:stretch-slim
+WORKDIR /usr/app
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/src/scylla/target/release/scylla .
+CMD ["./scylla"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+REPO=technosophos/scylla
+TAG=latest
+
+.PHONY: build
+build:
+	cargo build
+
+.PHONY: test
+test:
+	cargo test
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(REPO):$(TAG) .
+	docker push $(REPO) 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This project implements the [Hydra specification](https://github.com/microsoft/h
 
 **This is unstable, experimental, and subject to massively breaking changes. It may reflect the spec, or even features we are vetting before inclusion into the spec.**
 
+## Installing Using Helm
+
+A relatively recent version of Scylla can be installed using [Helm 3](helm.sh).
+
+```console
+$ helm install ./charts/scylla --generate-name
+```
+
+This will install the CRDs and the controller into your Kubernetes cluster.
+
+If you have already installed Scylla or are installing multiple copies of Scylla, you may need to add the `--no-hooks` flag.
+
 ## Building
 
 To build:

--- a/charts/scylla/.helmignore
+++ b/charts/scylla/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/scylla/Chart.yaml
+++ b/charts/scylla/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: scylla
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.1.0

--- a/charts/scylla/templates/NOTES.txt
+++ b/charts/scylla/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Scylla is a Kubernetes controller to manage Configuration CRDs.
+
+It has been successfully installed.

--- a/charts/scylla/templates/_helpers.tpl
+++ b/charts/scylla/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "scylla.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "scylla.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "scylla.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "scylla.labels" -}}
+app.kubernetes.io/name: {{ include "scylla.name" . }}
+helm.sh/chart: {{ include "scylla.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/scylla/templates/crds.tpl
+++ b/charts/scylla/templates/crds.tpl
@@ -1,0 +1,79 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: components.core.hydra.io
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  group: core.hydra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: components
+    singular: component
+    kind: Component
+    shortNames:
+    - comp
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: applications.core.hydra.io
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  group: core.hydra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: applications
+    singular: application
+    kind: Application
+    shortNames:
+    - app
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+ name: configurations.core.hydra.io
+ annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  group: core.hydra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: configurations
+    singular: configuration
+    kind: Configuration
+    shortNames:
+    - cfg
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: traits.core.hydra.io
+  annotations:
+    "helm.sh/hook": "pre-install"
+spec:
+  group: core.hydra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: traits
+    singular: trait
+    kind: Trait
+    shortNames:
+    - trait

--- a/charts/scylla/templates/deployment.yaml
+++ b/charts/scylla/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "scylla.fullname" . }}
+  labels:
+{{ include "scylla.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "scylla.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "scylla.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/scylla/values.yaml
+++ b/charts/scylla/values.yaml
@@ -1,0 +1,31 @@
+# Default values for scylla.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: technosophos/scylla
+  tag: latest # We're in pre-release
+  pullPolicy: Always
+
+nameOverride: ""
+fullnameOverride: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This adds the ability to dockerize Scylla and then install it via Helm chart