### PR TITLE
Fixed broken hostname

### DIFF
--- a/src/schematic/traits/ingress.rs
+++ b/src/schematic/traits/ingress.rs
@@ -36,8 +36,8 @@ impl Ingress {
                 .unwrap_or(80),
             hostname: params
                 .get("hostname".into())
-                .and_then(|p| Some(p.to_string())),
-            path: params.get("path".into()).and_then(|p| Some(p.to_string())),
+                .and_then(|p| Some(p.as_str().unwrap_or("").to_string())),
+            path: params.get("path".into()).and_then(|p| Some(p.as_str().unwrap_or("").to_string())),
             owner_ref: owner_ref,
         }
     }

--- a/src/schematic/traits/ingress_test.rs
+++ b/src/schematic/traits/ingress_test.rs
@@ -40,7 +40,7 @@ fn test_ingress() {
         .get(0)
         .expect("a rule is required");
     assert_eq!(
-        "\"in.example.com\"",
+        "in.example.com",
         rule.host.as_ref().expect("host is required").to_string()
     );
 
@@ -52,7 +52,7 @@ fn test_ingress() {
         .get(0)
         .expect("at least one path is required");
     assert_eq!(
-        "\"/path\"",
+        "/path",
         path.clone().path.expect("must be a path.path").as_str()
     );
     assert_eq!("my-ingress", path.backend.service_name.as_str());


### PR DESCRIPTION
Fixed my own knuckle-headed mistake where I was calling `to_string()` on an `Option<&str>` instead of on the `&str` itself, which left quotes around it.

Thanks to @chzbrgr71 for catching this.