### PR TITLE
fix: Allow turning off RBAC

### DIFF
--- a/charts/scylla/templates/rolebinding.yaml
+++ b/charts/scylla/templates/rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ include "scylla.labels" . | indent 4 }}
 
+{{ if .Values.enableRBAC }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,3 +35,4 @@ subjects:
 roleRef:
   kind: Role
   name: {{ template "scylla.fullname" . }}
+{{ end }}

--- a/charts/scylla/values.yaml
+++ b/charts/scylla/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: latest # We're in pre-release
   pullPolicy: Always
 
+# Turning this off will omit the Role and RoleBinding declarations.
+enableRBAC: true
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This makes it possible for turning off RBAC on clusters that do not have it enabled.