### PR TITLE
support non-default namespaces

### DIFF
--- a/charts/scylla/templates/deployment.yaml
+++ b/charts/scylla/templates/deployment.yaml
@@ -19,6 +19,11 @@ spec:
       serviceAccountName: {{ template "scylla.fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/scylla/templates/rolebinding.yaml
+++ b/charts/scylla/templates/rolebinding.yaml
@@ -31,7 +31,6 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "scylla.fullname" . }}
-  namespace: "default"  # FIXME
 roleRef:
   kind: Role
   name: {{ template "scylla.fullname" . }}

--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -29,7 +29,6 @@ pub struct ComponentNotFoundError {
     name: String,
 }
 
-const DEFAULT_NAMESPACE: &'static str = "default";
 
 /// An Instigator takes an inbound object and manages the reconcilliation with the desired objects.
 ///
@@ -133,13 +132,13 @@ impl Instigator {
                 Phase::Add => {
                     info!("Adding component {}", component.name.clone());
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::PreAdd,
                     )?;
                     workload.add()?;
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::Add,
                     )?;
@@ -147,13 +146,13 @@ impl Instigator {
                 Phase::Modify => {
                     info!("Modifying component {}", component.name.clone());
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::PreModify,
                     )?;
                     workload.modify()?;
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::Modify,
                     )?;
@@ -161,13 +160,13 @@ impl Instigator {
                 Phase::Delete => {
                     info!("Deleting component {}", component.name.clone());
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::PreDelete,
                     )?;
                     workload.delete()?;
                     trait_manager.exec(
-                        DEFAULT_NAMESPACE.into(),
+                        self.namespace.as_str(),
                         self.client.clone(),
                         Phase::Delete,
                     )?;
@@ -210,7 +209,7 @@ impl Instigator {
                     name: config_name,
                     instance_name: instance_name,
                     component_name: comp.metadata.name.clone(),
-                    namespace: DEFAULT_NAMESPACE.into(),
+                    namespace: self.namespace.clone(),
                     definition: comp.spec.clone(),
                     client: self.client.clone(),
                     params: params.clone(),
@@ -223,7 +222,7 @@ impl Instigator {
                     name: config_name,
                     instance_name: instance_name,
                     component_name: comp.metadata.name.clone(),
-                    namespace: DEFAULT_NAMESPACE.into(),
+                    namespace: self.namespace.clone(),
                     definition: comp.spec.clone(),
                     client: self.client.clone(),
                     params: params.clone(),
@@ -236,7 +235,7 @@ impl Instigator {
                     name: config_name,
                     instance_name: instance_name,
                     component_name: comp.metadata.name.clone(),
-                    namespace: DEFAULT_NAMESPACE.into(),
+                    namespace: self.namespace.clone(),
                     definition: comp.spec.clone(),
                     client: self.client.clone(),
                     params: params.clone(),
@@ -249,7 +248,7 @@ impl Instigator {
                     name: config_name,
                     instance_name: instance_name,
                     component_name: comp.metadata.name.clone(),
-                    namespace: DEFAULT_NAMESPACE.into(),
+                    namespace: self.namespace.clone(),
                     definition: comp.spec.clone(),
                     client: self.client.clone(),
                     params: params.clone(),


### PR DESCRIPTION
This supports running Scylla in non-default namespaces. It still restricts Scylla to creating resources in just one namespace, so #5 is still an open issue.