### PR TITLE
feat: Support imagePullSecret

### DIFF
--- a/examples/example-image-pull-secret.yaml
+++ b/examples/example-image-pull-secret.yaml
@@ -1,0 +1,29 @@
+#
+# To run this example, first create an image pull secret named 'example-image-pull-secret'
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# kubectl create secret docker-registry regcred --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
+#
+
+apiVersion: core.hydra.io/v1alpha1
+kind: Component
+metadata:
+  name: image-pull-secret-example
+spec:
+  workloadType: core.hydra.io/v1alpha1.ReplicableTask
+  os: linux
+  containers:
+    - name: runner
+      image: alpine:latest
+      imagePullSecret: example-image-pull-secret
+---
+apiVersion: core.hydra.io/v1alpha1
+kind: Configuration
+metadata:
+  name: example-image-pull-secret-task
+spec:
+  components:
+  - name: image-pull-secret-example
+    instanceName: one-image-pull-secret-task
+    parameterValues:
+      - name: message
+        value: Hello World


### PR DESCRIPTION
This adds per-component support for image pull secrets.

To create a new image pull secret, see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

Closes #73