### PR TITLE
*: replace `extern crate` with `use`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 kube = { version = "0.12.0", features = ["openapi"] }
 k8s-openapi = { version = "0.4.0", features = ["v1_13"] }
-#kube = { git = "https://github.com/clux/kube-rs", rev = "2624341b8abc7b6cfaa3c9cb31db716db44d10e8" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,6 @@
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-extern crate k8s_openapi;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
 
 pub mod instigator;
 pub mod lifecycle;

--- a/src/schematic.rs
+++ b/src/schematic.rs
@@ -1,3 +1,5 @@
+use failure::{err_msg, Error};
+
 pub mod component;
 pub mod component_instance;
 pub mod configuration;
@@ -65,16 +67,16 @@ impl GroupVersionKind {
         }
     }
     /// Parse a string into a GroupVersionKind.
-    pub fn from_str(gvp: &str) -> Result<GroupVersionKind, failure::Error> {
+    pub fn from_str(gvp: &str) -> Result<GroupVersionKind, Error> {
         // I suspect that this function could be made much more elegant.
         let parts: Vec<&str> = gvp.splitn(2, "/").collect();
         if parts.len() != 2 {
-            return Err(failure::err_msg("missing version and kind"));
+            return Err(err_msg("missing version and kind"));
         }
 
         let vk: Vec<&str> = parts.get(1).unwrap().splitn(2, ".").collect();
         if vk.len() != 2 {
-            return Err(failure::err_msg("missing kind"));
+            return Err(err_msg("missing kind"));
         }
 
         Ok(GroupVersionKind {

--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -1,9 +1,10 @@
+use failure::Error;
 use k8s_openapi::api::apps::v1 as apps;
 use k8s_openapi::api::core::v1 as core;
 use k8s_openapi::apimachinery::pkg::{
     api::resource::Quantity, apis::meta::v1 as meta, util::intstr::IntOrString,
 };
-
+use log::info;
 use std::collections::BTreeMap;
 
 use crate::schematic::parameter::{ParameterList, ParameterType};
@@ -30,7 +31,7 @@ pub struct Component {
 }
 impl Component {
     /// Parse JSON data into a Component.
-    pub fn from_str(json_data: &str) -> Result<Component, failure::Error> {
+    pub fn from_str(json_data: &str) -> Result<Component, Error> {
         let res: Component = serde_json::from_str(json_data)?;
         Ok(res)
     }

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -1,5 +1,3 @@
-extern crate spectral;
-
 use crate::schematic::{component::*, parameter::ParameterType, GroupVersionKind};
 
 #[test]

--- a/src/schematic/parameter.rs
+++ b/src/schematic/parameter.rs
@@ -1,3 +1,4 @@
+use failure::Error;
 use std::collections::BTreeMap;
 
 pub type ParameterList = Vec<Parameter>;
@@ -22,7 +23,7 @@ pub struct Parameter {
 }
 
 impl Parameter {
-    fn validate(&self, val: &serde_json::Value) -> Result<(), failure::Error> {
+    fn validate(&self, val: &serde_json::Value) -> Result<(), Error> {
         match self.parameter_type {
             ParameterType::Boolean => val
                 .as_bool()
@@ -52,14 +53,14 @@ type ResolvedVals = BTreeMap<String, serde_json::Value>;
 #[derive(Fail, Debug)]
 #[fail(display = "validation failed: {:?}", errs)]
 pub struct ValidationErrors {
-    errs: Vec<failure::Error>,
+    errs: Vec<Error>,
 }
 
 pub fn resolve_parameters(
     definition: Vec<Parameter>,
     values: ResolvedVals,
 ) -> Result<ResolvedVals, ValidationErrors> {
-    let mut errors: Vec<failure::Error> = Vec::new();
+    let mut errors: Vec<Error> = Vec::new();
     let mut resolved: ResolvedVals = BTreeMap::new();
 
     definition
@@ -107,7 +108,7 @@ pub fn resolve_parameters(
 pub fn resolve_values(
     current: Vec<ParameterValue>,
     parent: Vec<ParameterValue>,
-) -> Result<ResolvedVals, failure::Error> {
+) -> Result<ResolvedVals, Error> {
     let mut merged: ResolvedVals = BTreeMap::new();
 
     for p in current.iter() {

--- a/src/schematic/parameter_test.rs
+++ b/src/schematic/parameter_test.rs
@@ -1,4 +1,5 @@
 use crate::schematic::parameter::*;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 #[test]

--- a/src/schematic/traits.rs
+++ b/src/schematic/traits.rs
@@ -1,6 +1,7 @@
 use crate::lifecycle::Phase;
 use crate::schematic::parameter::ParameterValue;
 use kube::client::APIClient;
+use log::info;
 
 // Re-exports
 mod autoscaler;

--- a/src/schematic/traits/autoscaler_test.rs
+++ b/src/schematic/traits/autoscaler_test.rs
@@ -1,5 +1,6 @@
 use crate::schematic::traits::*;
 use crate::workload_type::ParamMap;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 #[test]

--- a/src/schematic/traits/ingress_test.rs
+++ b/src/schematic/traits/ingress_test.rs
@@ -1,6 +1,7 @@
 use crate::schematic::traits::*;
 use crate::workload_type::ParamMap;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 #[test]

--- a/src/schematic/traits/manual_scaler.rs
+++ b/src/schematic/traits/manual_scaler.rs
@@ -1,8 +1,8 @@
 use crate::schematic::traits::{util::*, TraitImplementation};
 use crate::workload_type::{ParamMap, REPLICATED_SERVICE_NAME, REPLICATED_TASK_NAME};
 use k8s_openapi::api::{apps::v1 as apps, batch::v1 as batch};
-
 use kube::client::APIClient;
+use log::info;
 
 /// A manual scaler provides a way to manually scale replicable objects.
 #[derive(Clone, Debug)]

--- a/src/schematic/traits/util.rs
+++ b/src/schematic/traits/util.rs
@@ -1,8 +1,9 @@
+use failure::Error;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as meta;
 use std::collections::BTreeMap;
 
 /// Alias for trait results.
-pub type TraitResult = Result<(), failure::Error>;
+pub type TraitResult = Result<(), Error>;
 /// Alias for a vector of owner references.
 pub type OwnerRefs = Option<Vec<meta::OwnerReference>>;
 /// Alias for a map of labels.

--- a/src/workload_type.rs
+++ b/src/workload_type.rs
@@ -1,3 +1,5 @@
+use failure::Error;
+use log::info;
 use std::collections::BTreeMap;
 
 mod service;
@@ -21,7 +23,7 @@ pub const SINGLETON_NAME: &'static str = "core.hydra.io/v1alpha1.Singleton";
 pub const TASK_NAME: &'static str = "core.hydra.io/v1alpha1.Task";
 pub const REPLICATED_TASK_NAME: &'static str = "core.hydra.io/v1alpha1.ReplicatedTask";
 
-type InstigatorResult = Result<(), failure::Error>;
+type InstigatorResult = Result<(), Error>;
 pub type ParamMap = BTreeMap<String, serde_json::Value>;
 
 /// KubeName describes anything that can produce its own Kubernetes name.

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -3,6 +3,7 @@ use k8s_openapi::api::core::v1 as api;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as meta;
 use kube::api::PostParams;
 use kube::client::APIClient;
+use log::info;
 use std::collections::BTreeMap;
 
 use crate::schematic::component::Component;
@@ -302,7 +303,7 @@ mod test {
             parameters: vec![],
             containers: vec![Container {
                 name: "foo".into(),
-                ports: vec![Port{
+                ports: vec![Port {
                     container_port: 80,
                     name: "http".into(),
                     protocol: PortProtocol::TCP,

--- a/src/workload_type_test.rs
+++ b/src/workload_type_test.rs
@@ -1,9 +1,10 @@
 use crate::workload_type::*;
+use failure::Error;
 
 struct MockWorkloadType {}
 
 impl WorkloadType for MockWorkloadType {
-    fn add(&self) -> Result<(), failure::Error> {
+    fn add(&self) -> Result<(), Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
According to latest doc:

  https://doc.rust-lang.org/nightly/edition-guide/rust-2018/module-system/path-clarity.html

`extern crate` is going away and replaced by `use`.
One exception in our code is `proc_macro`.