### PR TITLE
fix: rename Component kind to ComponentSchematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ kubectl create -f examples/components.yaml
 You can now list the components available to you:
 
 ```console
-$ kubectl get components
+$ kubectl get componentschematics
 NAME                     AGE
 alpine-replicable-task   19h
 alpine-task              19h
@@ -70,9 +70,9 @@ nginx-singleton          19h
 You can look at an individual component:
 
 ```console
-$ kubectl get component alpine-task -o yaml
+$ kubectl get componentschematic alpine-task -o yaml
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   creationTimestamp: "2019-08-08T03:31:36Z"
   generation: 1

--- a/charts/scylla/crds/componentschematics.yaml
+++ b/charts/scylla/crds/componentschematics.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: components.core.hydra.io
+  name: componentschematics.core.hydra.io
 spec:
   group: core.hydra.io
   versions:
@@ -10,8 +10,9 @@ spec:
       storage: true
   scope: Namespaced
   names:
-    plural: components
-    singular: component
-    kind: Component
+    plural: componentschematics
+    singular: componentschematic
+    kind: ComponentSchematic
     shortNames:
+    - component
     - comp

--- a/examples/components.yaml
+++ b/examples/components.yaml
@@ -1,5 +1,5 @@
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: hpa-example-replicated
 spec:
@@ -19,7 +19,7 @@ spec:
             required: 100M
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: nginx-replicated
 spec:
@@ -34,7 +34,7 @@ spec:
           protocol: TCP
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: nginx-singleton
 spec:
@@ -49,7 +49,7 @@ spec:
           protocol: TCP
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: alpine-task
 spec:
@@ -60,7 +60,7 @@ spec:
       image: alpine:latest
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: alpine-replicable-task
 spec:

--- a/examples/voting/components.yaml
+++ b/examples/voting/components.yaml
@@ -1,5 +1,5 @@
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: voting-admin
   version: "1.0.0"
@@ -14,7 +14,7 @@ spec:
       image: dockersamples/examplevotingapp_result:before
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: postgres
   version: "1.0.0"
@@ -29,7 +29,7 @@ spec:
       image: postgres:9.4
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: redis
   version: "1.0.0"
@@ -44,7 +44,7 @@ spec:
       image: redis:alpine
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: voting-frontend
   version: "1.0.0"
@@ -59,7 +59,7 @@ spec:
       image: dockersamples/examplevotingapp_vote:before
 ---
 apiVersion: core.hydra.io/v1alpha1
-kind: Component
+kind: ComponentSchematic
 metadata:
   name: voting-worker
   version: "1.0.0"

--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -85,7 +85,7 @@ impl Instigator {
         let owner_ref = config_owner_reference(name.clone(), event.metadata.uid.clone())?;
 
         for component in event.spec.components.unwrap_or_else(|| vec![]) {
-            let component_resource = RawApi::customResource("components")
+            let component_resource = RawApi::customResource("componentschematics")
                 .version("v1alpha1")
                 .group("core.hydra.io")
                 .within(&self.namespace);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Error> {
     let cfg_watch = top_cfg.clone();
     let client = APIClient::new(top_cfg);
 
-    let component_resource = RawApi::customResource("components")
+    let component_resource = RawApi::customResource("componentschematics")
         .within(top_ns.as_str())
         .group("core.hydra.io")
         .version("v1alpha1");


### PR DESCRIPTION
This might get changed back later, but it was determined that it was more important to keep parity with the managed service, and they can't quite switch over to Component yet.

BREAKING CHANGE: All Component kinds will need to be renamed ComponentSchematic

Closes #96