### PR TITLE
add make run && make cargo clippy happy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,7 @@ test:
 .PHONY: docker-build
 docker-build:
 	docker build -t $(REPO):$(TAG) .
-	docker push $(REPO) 
+	docker push $(REPO)
+
+run:
+	RUST_LOG="scylla=debug" RUST_BACKTRACE=short cargo run

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ To build:
 - Go into the main directory: `cd scylla`
 - Install the CRDs in `k8s/crds.yaml`: `kubectl create -f k8s/crds.yaml`
 - Run `cargo build`
-- To run the server: `cargo run`
+- To run the server: `make run`, this will run scylla controller locally, and use the cluster by your `~/.kube/config`.
 
 At this point, you will be running a local controller attached to the cluster to which your kubeconfig is pointing.
 

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -82,7 +82,7 @@ impl JobBuilder {
         self.parallelism = Some(count);
         self
     }
-    fn to_job(self) -> batchapi::Job {
+    fn to_job(&self) -> batchapi::Job {
         batchapi::Job {
             // TODO: Could make this generic.
             metadata: Some(meta::ObjectMeta {
@@ -154,7 +154,7 @@ impl ServiceBuilder {
         self.owner_ref = owner_ref;
         self
     }
-    fn to_service(self) -> Option<api::Service> {
+    fn to_service(&self) -> Option<api::Service> {
         self.component.clone().listening_port().and_then(|port| {
             Some(api::Service {
                 metadata: Some(meta::ObjectMeta {
@@ -164,7 +164,7 @@ impl ServiceBuilder {
                     ..Default::default()
                 }),
                 spec: Some(api::ServiceSpec {
-                    selector: Some(self.labels),
+                    selector: Some(self.labels.clone()),
                     ports: Some(vec![port.to_service_port()]),
                     ..Default::default()
                 }),


### PR DESCRIPTION
```
➜  scylla git:(cragorun) ✗ cargo clippy
    Checking scylla v0.1.0 (/Users/sunjianbo/codebox/scylla)
warning: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
  --> src/workload_type/workload_builder.rs:85:15
   |
85 |     fn to_job(self) -> batchapi::Job {
   |               ^^^^
   |
   = note: #[warn(clippy::wrong_self_convention)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
   --> src/workload_type/workload_builder.rs:157:19
    |
157 |     fn to_service(self) -> Option<api::Service> {
    |                   ^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

    Finished dev [unoptimized + debuginfo] target(s) in 4.73s
```