### PR TITLE
Expose a semi-configurable port on the service

### DIFF
--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -247,9 +247,9 @@ impl Port {
     pub fn to_service_port(&self) -> core::ServicePort {
         let port = self.container_port;
         core::ServicePort {
+            port,
             target_port: Some(IntOrString::Int(port)),
             name: Some(self.name.clone()),
-            port: port,
             protocol: Some(self.protocol.to_string()),
             ..Default::default()
         }

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use std::str::FromStr;
 
 use crate::schematic::{component::*, parameter::ParameterType, GroupVersionKind};
 
@@ -80,59 +80,59 @@ fn test_container_deserialize_defaults() {
 }
 
 #[test]
+#[allow(clippy::cognitive_complexity)]
 fn test_container_deserialize() {
-    let data = Component::from_str(
-        r#"{
-            "containers": [
-                {
-                    "name": "my_container",
-                    "image": "nginx:latest",
-                    "ports": [
-                        {
-                            "name": "http",
-                            "containerPort": 8080,
-                            "protocol": "TCP"
-                        },
-                        {
-                            "name": "admin",
-                            "containerPort": 31337,
-                            "protocol": "UDP"
-                        }
-                    ],
-                    "cmd":["nginx-debug"],
-                    "args":["-g","daemon off;"],
-                    "env": [
-                        {
-                            "name": "key1",
-                            "value": "value1"
-                        },
-                        {
-                            "name": "key2",
-                            "fromParam": "param2"
-                        }
-                    ],
-                    "livenessProbe": {},
-                    "resources": {
-                        "memory": {
-                            "required": "2G"
-                        },
-                        "volumes": [
-                            {
-                                "name": "first",
-                                "mountPath": "/path/to/first"
-                            },
-                            {
-                                "name": "second",
-                                "mountPath": "/path/to/second",
-                                "accessMode": "RO",
-                                "sharingPolicy": "Shared"
-                            }
-                        ]
+    let def = r#"{
+        "containers": [
+            {
+                "name": "my_container",
+                "image": "nginx:latest",
+                "ports": [
+                    {
+                        "name": "http",
+                        "containerPort": 8080,
+                        "protocol": "TCP"
+                    },
+                    {
+                        "name": "admin",
+                        "containerPort": 31337,
+                        "protocol": "UDP"
                     }
+                ],
+                "cmd":["nginx-debug"],
+                "args":["-g","daemon off;"],
+                "env": [
+                    {
+                        "name": "key1",
+                        "value": "value1"
+                    },
+                    {
+                        "name": "key2",
+                        "fromParam": "param2"
+                    }
+                ],
+                "livenessProbe": {},
+                "resources": {
+                    "memory": {
+                        "required": "2G"
+                    },
+                    "volumes": [
+                        {
+                            "name": "first",
+                            "mountPath": "/path/to/first"
+                        },
+                        {
+                            "name": "second",
+                            "mountPath": "/path/to/second",
+                            "accessMode": "RO",
+                            "sharingPolicy": "Shared"
+                        }
+                    ]
                 }
-            ]
-        }"#,
-    );
+            }
+        ]
+    }"#;
+    let data = Component::from_str(def);
 
     assert!(data.is_ok(), "{}", data.unwrap_err());
 
@@ -184,6 +184,7 @@ fn test_container_deserialize() {
     assert_eq!(SharingPolicy::Shared, path2.sharing_policy);
     assert_eq!(AccessMode::RO, path2.access_mode);
 }
+
 #[test]
 fn test_health_probe_deserialize() {
     let data = Component::from_str(
@@ -456,11 +457,14 @@ fn test_to_env_vars() {
 
 #[test]
 fn test_to_service_port() {
-    let port = Port{
+    let port = Port {
         name: "test".into(),
         container_port: 443,
         protocol: PortProtocol::TCP,
     };
     assert_eq!(443, port.to_service_port().port);
-    assert_eq!(IntOrString::Int(443), port.to_service_port().target_port.expect("port"));
+    assert_eq!(
+        IntOrString::Int(443),
+        port.to_service_port().target_port.expect("port")
+    );
 }

--- a/src/schematic/parameter_test.rs
+++ b/src/schematic/parameter_test.rs
@@ -93,12 +93,12 @@ fn test_resolve_values() {
     let merged = resolve_values(child, parent).expect("resolve parent values into child");
     assert_eq!(
         Some("house"),
-        merged.get("abode".into()).expect("abode is home").as_str()
+        merged.get("abode").expect("abode is home").as_str()
     );
     assert_eq!(
         Some("dog"),
         merged
-            .get("favorite_animal".into())
+            .get("favorite_animal")
             .expect("abode is home")
             .as_str()
     );


### PR DESCRIPTION
The spec currently gives no guidance on what the external port number on a service should be, or how it is to be configured. So for the time being, we just mirror the container port. This is relatively safe, but not terribly flexible.

Closes #108