### PR TITLE
change dockerfile to speed up docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 FROM rust:1.36 AS builder
 WORKDIR /usr/src/scylla
-COPY ./src ./src
+
 COPY Cargo.toml .
 COPY Cargo.lock .
+
+# Create dummy files to build the dependencies, cargo won't build without src/main.rs and src/lib.rs
+# then remove Scylla fingerprint for following rebuild
+RUN mkdir -p ./src/ && \
+    echo 'fn main() {}' > ./src/main.rs && \
+    echo '' > ./src/lib.rs
+RUN cargo build --release && \
+    rm -rf ./target/release/.fingerprint/scylla-*
+
+# Build real binaries now
+COPY ./src ./src
 RUN cargo build --release
 RUN ls -lah ./target/release
 


### PR DESCRIPTION
we can't mount when executing docker build, only `COPY` or `ADD` all the caches, I find a way to cache the files, it can also fixes #112 