### PR TITLE
fix component workload type in examples

### DIFF
--- a/examples/components.yaml
+++ b/examples/components.yaml
@@ -62,9 +62,9 @@ spec:
 apiVersion: core.hydra.io/v1alpha1
 kind: ComponentSchematic
 metadata:
-  name: alpine-replicable-task
+  name: alpine-singleton-task
 spec:
-  workloadType: core.hydra.io/v1alpha1.ReplicableTask
+  workloadType: core.hydra.io/v1alpha1.SingletonTask
   os: linux
   containers:
     - name: runner

--- a/examples/example-image-pull-secret.yaml
+++ b/examples/example-image-pull-secret.yaml
@@ -9,7 +9,7 @@ kind: ComponentSchematic
 metadata:
   name: image-pull-secret-example
 spec:
-  workloadType: core.hydra.io/v1alpha1.ReplicableTask
+  workloadType: core.hydra.io/v1alpha1.Task
   os: linux
   containers:
     - name: runner

--- a/examples/example-replicable-task.yaml
+++ b/examples/example-replicable-task.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-replicable-task
 spec:
   components:
-  - name: alpine-replicable-task
+  - name: alpine-task
     instanceName: multi-alpine-task
     parameterValues:
       - name: message

--- a/examples/example-task.yaml
+++ b/examples/example-task.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-task
 spec:
   components:
-  - name: alpine-task
+  - name: alpine-singleton-task
     instanceName: one-alpine-task
     parameterValues:
       - name: message


### PR DESCRIPTION
I find there are some confusion in examples.

We declare it here:

* `core.hydra.io/v1alpha1.Service` => `ReplicatedServiceType`
* `core.hydra.io/v1alpha1.SingletonService` => `SingletonServiceType`
* `core.hydra.io/v1alpha1.SingletonTask` => `SingletonServiceType`
* `core.hydra.io/v1alpha1.Task` => `ReplicatedTaskType`
* `core.hydra.io/v1alpha1.SingletonWorker` => `SingletonWorkerType`
* `core.hydra.io/v1alpha1.Worker` => `ReplicatedWorkerType`

