### PR TITLE
fix serviceworkload with wrong service bind

### DIFF
--- a/examples/first-app-config.yaml
+++ b/examples/first-app-config.yaml
@@ -18,3 +18,5 @@ spec:
             value: example.com
           - name: path
             value: /
+          - name: service_port
+            value: 80

--- a/src/schematic/traits/ingress.rs
+++ b/src/schematic/traits/ingress.rs
@@ -44,11 +44,13 @@ impl Ingress {
         }
     }
     pub fn to_ext_ingress(&self) -> ext::Ingress {
+        let mut labels = trait_labels();
+        labels.insert("app".to_string(), self.name.clone());
         ext::Ingress {
             metadata: Some(meta::ObjectMeta {
                 //name: Some(format!("{}-trait-ingress", self.name.clone())),
                 name: Some(self.kube_name()),
-                labels: Some(trait_labels()),
+                labels: Some(labels),
                 owner_references: self.owner_ref.clone(),
                 ..Default::default()
             }),
@@ -61,7 +63,7 @@ impl Ingress {
                     http: Some(ext::HTTPIngressRuleValue {
                         paths: vec![ext::HTTPIngressPath {
                             backend: ext::IngressBackend {
-                                service_name: self.name.clone(),
+                                service_name: self.instance_name.clone(),
                                 service_port: IntOrString::Int(self.svc_port),
                             },
                             path: self.path.clone().or_else(|| Some("/".to_string())),

--- a/src/schematic/traits/ingress_test.rs
+++ b/src/schematic/traits/ingress_test.rs
@@ -56,7 +56,7 @@ fn test_ingress() {
         "/path",
         path.clone().path.expect("must be a path.path").as_str()
     );
-    assert_eq!("my-ingress", path.backend.service_name.as_str());
+    assert_eq!("squid", path.backend.service_name.as_str());
     assert_eq!(IntOrString::Int(8080), path.backend.service_port);
 }
 

--- a/src/workload_type/service.rs
+++ b/src/workload_type/service.rs
@@ -58,8 +58,11 @@ impl WorkloadType for ReplicatedService {
         let mut labels = BTreeMap::new();
         labels.insert("app".to_string(), self.meta.name.clone());
         labels.insert("workload-type".to_string(), "service".to_string());
+        let mut select_labels = BTreeMap::new();
+        select_labels.insert("app".to_string(), self.meta.name.clone());
         ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
             .labels(labels)
+            .select_labels(select_labels)
             .owner_reference(self.meta.owner_ref.clone())
             .do_request(self.meta.client.clone(), self.meta.namespace.clone())
     }


### PR DESCRIPTION
fixes https://github.com/microsoft/scylla/issues/119

There are two places I fixed:

1. ingress bind: we should use `instance_name` instead of `name`, to be consistent with service
2. service select labels: we should distinguish with `labels` and `select_labels`