### PR TITLE
don't change status when delete

### DIFF
--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -198,6 +198,11 @@ impl Instigator {
                 }
             }
         }
+
+        if phase == Phase::Delete {
+            return Ok(());
+        }
+
         if let Some(s) = event.status.clone() {
             if let Some(hs) = s.clone() {
                 if hs.phase.is_some() && hs.phase.unwrap() == phase.to_string() {

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -35,7 +35,7 @@ use std::fmt;
 /// Note that in deletion operations, Kubernetes will delete by owner reference before PreDelete. This means
 /// that the components will likely be unavailable by the time PreDelete fires. It is only guaranteed to fire
 /// before the component's Delete operation is fired.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Phase {
     // PreAdd happens before resources are added
     PreAdd,


### PR DESCRIPTION
when I add status update, I forgot to filter "delete" phase. 

I can't update status when the event is delete, because the object is gone.