### PR TITLE
add plurals to short names

### DIFF
--- a/charts/scylla/crds/componentschematics.yaml
+++ b/charts/scylla/crds/componentschematics.yaml
@@ -14,5 +14,6 @@ spec:
     singular: componentschematic
     kind: ComponentSchematic
     shortNames:
-    - component
-    - comp
+      - component
+      - comp
+      - components

--- a/charts/scylla/crds/opsconfigs.yaml
+++ b/charts/scylla/crds/opsconfigs.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
- name: operationalconfigurations.core.hydra.io
+  name: operationalconfigurations.core.hydra.io
 spec:
   group: core.hydra.io
   versions:
@@ -14,5 +14,6 @@ spec:
     singular: operationalconfiguration
     kind: OperationalConfiguration
     shortNames:
-    - cfg
-    - configuration
+      - cfg
+      - configuration
+      - configurations


### PR DESCRIPTION
This just adds plurals to the CRD aliases to reduce friction as we rename things.

To test, you will need to delete the CRDs and re-install them.

Closes #143 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>