### PR TITLE
use node selector for component osType and arch specify

### DIFF
--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -38,13 +38,22 @@ impl Component {
             .find_map(|e| e.ports.iter().find_map(Some))
     }
 
+    pub fn to_node_selector(&self) -> Option<BTreeMap<String, String>> {
+        let mut selector = BTreeMap::new();
+        selector.insert("kubernetes.io/os".to_string(), self.os_type.clone());
+        selector.insert("kubernetes.io/arch".to_string(), self.arch.clone());
+        Some(selector)
+    }
+
     /// to_pod_spec generates a pod specification.
     pub fn to_pod_spec(&self, param_vals: ResolvedVals) -> core::PodSpec {
         let containers = self.to_containers(param_vals);
         let image_pull_secrets = Some(self.image_pull_secrets());
+        let node_selector = self.to_node_selector();
         core::PodSpec {
             containers,
             image_pull_secrets,
+            node_selector,
             ..Default::default()
         }
     }

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -468,3 +468,20 @@ fn test_to_service_port() {
         port.to_service_port().target_port.expect("port")
     );
 }
+
+#[test]
+fn test_to_node_seletor() {
+    let data = Component::from_str(
+        r#"{
+            "osType":"linux",
+            "arch":"amd64"
+        }"#,
+    );
+    assert!(data.is_ok(), "Not okay: {}", data.unwrap_err());
+
+    let comp = data.unwrap();
+    let mut selector = std::collections::BTreeMap::new();
+    selector.insert("kubernetes.io/os".to_string(), "linux".to_string());
+    selector.insert("kubernetes.io/arch".to_string(), "amd64".to_string());
+    assert_eq!(Some(selector), comp.to_node_selector())
+}


### PR DESCRIPTION
Use Kubernetes [node selector](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#kubernetes-io-arch) to specify component osType and arch.