### PR TITLE
Initial infrastructure for E2E using Kind

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,16 +4,28 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Env check
-      run: rustc --version
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Style check
-      run: cargo clippy
+      - uses: actions/checkout@v1
+      - name: Env check
+        run: rustc --version
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - uses: engineerd/setup-kind@v0.1.0
+      - uses: engineerd/configurator@v0.0.1
+        with:
+          name: helm
+          url: https://get.helm.sh/helm-v3.0.0-beta.3-linux-amd64.tar.gz
+          pathInArchive: linux-amd64/helm
+      - name: Kubernetes E2E
+        run: |
+          export KUBECONFIG="$(kind get kubeconfig-path)"
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          kubectl wait -n kube-system --for=condition=Ready -l k8s-app=kube-dns pods
+          make kind-e2e
+      - name: Style check
+        run: cargo clippy

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,6 @@
+FROM debian:stretch-slim
+WORKDIR /usr/app
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
+COPY debug/scylla .
+ENV RUST_LOG scylla=info
+CMD ["./scylla"]

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,16 @@ docker-build:
 
 run:
 	RUST_LOG="scylla=debug" RUST_BACKTRACE=short cargo run
+
+GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
+kind-e2e:
+	make build && \
+	docker build -t $(REPO):$(GIT_VERSION) -f Dockerfile.e2e target/ && \
+	kind load docker-image $(REPO):$(GIT_VERSION) \
+		|| echo >&2 "kind not installed or error loading image: $(REPO):$(GIT_VERSION)" && \
+	helm version && \
+	helm install scylla ./charts/scylla --set image.repository=$(REPO) --set image.tag=$(GIT_VERSION) --set image.pullPolicy=IfNotPresent --wait && \
+	kubectl get trait && \
+    kubectl apply -f examples/components.yaml && \
+    kubectl get componentschematics && \
+    kubectl get componentschematic alpine-task -o yaml


### PR DESCRIPTION
addresses #115 

This PR adds initial support for running end-to-end tests in GitHub Actions, using Kind.

It adds a `kind-e2e` Make target that should only be used by the GitHub Action - this is because it: 
- assumes a Linux environment and builds a container image based on the current changes - it uses the local build artifacts because building the container image based on the current Dockerfile takes at least 20 minutes with the GH Actions infrastructure
- assumes Kind and Helm3 are configured (they are configured by the Action)
- installs the Helm chart using the newly built image, then applies the components in the example.

This is not adding any checks for the desired outputs as I'm not yet familiar as to what those outputs should be (feel free to suggest or add them).

For a successful action run, [see this PR](https://github.com/radu-matei/scylla/pull/1/checks?check_run_id=233764158).