### PR TITLE
fix: consistently add node selector to pod specs

### DIFF
--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -90,8 +90,11 @@ impl Component {
     ) -> core::PodSpec {
         let containers = self.to_containers(param_vals);
         let image_pull_secrets = Some(self.image_pull_secrets());
+        let node_selector = self.to_node_selector();
+
         core::PodSpec {
             containers,
+            node_selector,
             image_pull_secrets,
             restart_policy: Some(restart_policy),
             ..Default::default()

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -488,6 +488,74 @@ fn test_to_node_seletor() {
 }
 
 #[test]
+fn test_to_pod_spec_with_policy() {
+    let component = Component::from_str(
+        r#"{
+            "osType": "linux",
+            "arch": "arm64",
+            "containers": [
+                {
+                    "name": "my_container",
+                    "image": "nginx:latest",
+                    "livenessProbe": {
+                        "httpGet": {
+                            "path": "/healthz",
+                            "port": 9000,
+                            "httpHeaders": [
+                                {
+                                    "name": "HOSTNAME",
+                                    "value": "example.com"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }"#,
+    )
+    .expect("component must parse");
+
+    // This is a regression test for issue #189
+    {
+        let map = BTreeMap::new();
+        let pod = component
+            .clone()
+            .to_pod_spec_with_policy(map, "Always".to_string());
+        let node_selector = pod.node_selector.clone().expect("node selector btree");
+        assert_eq!(
+            "linux".to_string(),
+            *node_selector
+                .get("kubernetes.io/os")
+                .expect("an OS should be present")
+        );
+        assert_eq!(
+            "arm64".to_string(),
+            *node_selector
+                .get("kubernetes.io/arch")
+                .expect("an arch should be present")
+        );
+    }
+
+    {
+        let map = BTreeMap::new();
+        let pod = component.to_pod_spec(map);
+        let node_selector = pod.node_selector.clone().expect("node selector btree");
+        assert_eq!(
+            "linux".to_string(),
+            *node_selector
+                .get("kubernetes.io/os")
+                .expect("an OS should be present")
+        );
+        assert_eq!(
+            "arm64".to_string(),
+            *node_selector
+                .get("kubernetes.io/arch")
+                .expect("an arch should be present")
+        );
+    }
+}
+
+#[test]
 fn test_evaluate_configs() {
     let comp_res = Component::from_str(
         r#"{


### PR DESCRIPTION
This adds node selectors to pod specs in both methods.

Partially closes #189