### PR TITLE
fix(charts): use apiVersion apps/v1 for Deployments

### DIFF
--- a/charts/scylla/templates/deployment.yaml
+++ b/charts/scylla/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "scylla.fullname" . }}


### PR DESCRIPTION
apps/v1beta2 was dropped in Kubernetes 1.16.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>