### PR TITLE
fix(charts): fix incorrect apiVersion linter error

### DIFF
--- a/charts/scylla/Chart.yaml
+++ b/charts/scylla/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: scylla
 description: A Helm chart for Kubernetes
 


### PR DESCRIPTION
[ERROR] Chart.yaml: chart type is not valid in apiVersion 'v1'. It is valid in apiVersion 'v2'

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>