### PR TITLE
expose RUST_LOG as a chart config

### DIFF
--- a/charts/scylla/templates/deployment.yaml
+++ b/charts/scylla/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+            - name: RUST_LOG
+              value: {{ .Values.logLevel | default "scylla=info" | quote}}
             - name: KUBERNETES_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/scylla/values.yaml
+++ b/charts/scylla/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+logLevel: "scylla=info"
 
 image:
   repository: hydraoss/scylla
@@ -15,7 +16,8 @@ enableRBAC: true
 nameOverride: ""
 fullnameOverride: ""
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
This just exposes `RUST_LOG` as a configurable variable in the chart. Useful when you need to turn `scylla=debug` on.