### PR TITLE
Enable nightly container image publishing for amd64 and arm64

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,16 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Container Images
+        run: make docker-build-cx
+      - name: Publish Container Images
+        run: make docker-publish

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Validate arm64 build
-        run: make docker-build-cx
       - name: Env check
         run: rustc --version
       - name: Build

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,11 @@ kind-e2e:
 
 docker-build-cx:
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-	docker build -t $(REPO):arm64 -f Dockerfile --build-arg BUILDER_IMAGE=arm64v8/rust:1.37 --build-arg BASE_IMAGE=arm64v8/debian:stretch-slim .
-	docker build -t $(REPO):amd64 .
-	docker manifest create $(REPO):$(TAG) $(REPO):amd64 $(REPO):arm64
+	docker build -t $(REPO)-arm64:$(TAG) -f Dockerfile --build-arg BUILDER_IMAGE=arm64v8/rust:1.37 --build-arg BASE_IMAGE=arm64v8/debian:stretch-slim .
+	docker build -t $(REPO)-amd64:$(TAG) .
 
 docker-publish: docker-build-cx
+	docker push $(REPO)-amd64:$(TAG)
+	docker push $(REPO)-arm64:$(TAG)
+	docker manifest create $(REPO):$(TAG) $(REPO)-amd64:$(TAG) $(REPO)-arm64:$(TAG)
 	docker manifest push $(REPO):$(TAG)


### PR DESCRIPTION
This PR enables nightly workflow to build and publish arm64 and amd64 container images and link them through a manifest.