### PR TITLE
fix(schematic): match to_pod_spec_with_policy with to_pod_spec output

### DIFF
--- a/examples/nginx-component.yaml
+++ b/examples/nginx-component.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx-component
 spec:
   name: nginx-component
-  workloadType: core.hydra.io/v1alpha1.Singleton
+  workloadType: core.hydra.io/v1alpha1.SingletonServer
   osType: linux
   arch: amd64
   containers:

--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -95,17 +95,9 @@ impl Component {
         param_vals: ResolvedVals,
         restart_policy: String,
     ) -> core::PodSpec {
-        let containers = self.to_containers(param_vals);
-        let image_pull_secrets = Some(self.image_pull_secrets());
-        let node_selector = self.to_node_selector();
-
-        core::PodSpec {
-            containers,
-            node_selector,
-            image_pull_secrets,
-            restart_policy: Some(restart_policy),
-            ..Default::default()
-        }
+        let mut pod_spec = self.to_pod_spec(param_vals);
+        pod_spec.restart_policy = Some(restart_policy);
+        pod_spec
     }
 
     pub fn evaluate_configs(


### PR DESCRIPTION
This fixes an issue where a call to `to_pod_spec_with_policy` returns a pod template with no `volumes` defined matching the error identified in https://github.com/microsoft/scylla/pull/244#issuecomment-537192414.

Also fixes an issue with the example components missed in #246.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>