### PR TITLE
ref: remove unused/dead code

### DIFF
--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -1,7 +1,6 @@
-use k8s_openapi::api::apps::v1 as apps;
 use k8s_openapi::api::core::v1 as core;
 use k8s_openapi::apimachinery::pkg::{
-    api::resource::Quantity, apis::meta::v1 as meta, util::intstr::IntOrString,
+    api::resource::Quantity, util::intstr::IntOrString,
 };
 use log::info;
 use std::collections::BTreeMap;
@@ -192,30 +191,6 @@ impl Component {
                 })
             })
             .collect()
-    }
-
-    pub fn to_deployment_spec(
-        &self,
-        param_vals: ResolvedVals,
-        labels: Option<BTreeMap<String, String>>,
-        annotations: Option<BTreeMap<String, String>>,
-    ) -> apps::DeploymentSpec {
-        apps::DeploymentSpec {
-            replicas: Some(1),
-            selector: meta::LabelSelector {
-                match_labels: labels.clone(),
-                ..Default::default()
-            },
-            template: core::PodTemplateSpec {
-                metadata: Some(meta::ObjectMeta {
-                    annotations,
-                    labels: labels.clone(),
-                    ..Default::default()
-                }),
-                spec: Some(self.to_pod_spec(param_vals)),
-            },
-            ..Default::default()
-        }
     }
 }
 

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -691,38 +691,3 @@ fn test_evaluate_configs() {
     exp.insert("container30".to_string(), c30);
     assert_eq!(exp, configs);
 }
-
-#[test]
-fn test_to_deployment_spec() {
-    let comp_res = Component::from_str(
-        r#"{
-            "parameters": [
-                {
-                    "name": "one",
-                    "type": "string",
-                    "default": "test one"
-                }
-            ],
-            "containers": [
-                {
-                    "name": "container1",
-                    "image": "nginx:latest"
-                }
-            ]
-        }"#,
-    );
-    let comp = comp_res.as_ref().expect("component should exist");
-    let mut labels = BTreeMap::new();
-    labels.insert(
-        "app.kubernetes.io/name".to_string(),
-        "test_deploy".to_string(),
-    );
-    let resloved_val =
-        resolve_parameters(comp.parameters.clone(), BTreeMap::new()).expect("resolved parameter");
-    let deploy = comp.to_deployment_spec(resloved_val, Some(labels.clone()), None);
-    assert_eq!(deploy.selector.match_labels, Some(labels.clone()));
-    assert_eq!(
-        deploy.template.metadata.unwrap().labels,
-        Some(labels.clone())
-    );
-}


### PR DESCRIPTION
Removes unused imports as well as any code that isn't used anywhere in scylla. Removes all the compiler warnings when running `cargo build` or `cargo test`.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>