### PR TITLE
ref: DRY up label generation

### DIFF
--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -688,7 +688,7 @@ fn test_to_deployment_spec() {
     );
     let comp = comp_res.as_ref().expect("component should exist");
     let mut labels = BTreeMap::new();
-    labels.insert("app".to_string(), "test_deploy".to_string());
+    labels.insert("app.kubernetes.io/name".to_string(), "test_deploy".to_string());
     let resloved_val =
         resolve_parameters(comp.parameters.clone(), BTreeMap::new()).expect("resolved parameter");
     let deploy = comp.to_deployment_spec(resloved_val, Some(labels.clone()), None);

--- a/src/schematic/traits/ingress.rs
+++ b/src/schematic/traits/ingress.rs
@@ -45,7 +45,7 @@ impl Ingress {
     }
     pub fn to_ext_ingress(&self) -> ext::Ingress {
         let mut labels = trait_labels();
-        labels.insert("app".to_string(), self.name.clone());
+        labels.insert("app.kubernetes.io/name".to_string(), self.name.clone());
         ext::Ingress {
             metadata: Some(meta::ObjectMeta {
                 //name: Some(format!("{}-trait-ingress", self.name.clone())),

--- a/src/workload_type/service.rs
+++ b/src/workload_type/service.rs
@@ -17,10 +17,7 @@ pub struct ReplicatedService {
 
 impl ReplicatedService {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "Service".to_string());
-        labels
+        self.meta.labels("Service")
     }
 }
 
@@ -114,10 +111,7 @@ pub struct SingletonService {
 }
 impl SingletonService {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "SingletonService".to_string());
-        labels
+        self.meta.labels("SingletonService")
     }
 }
 

--- a/src/workload_type/task.rs
+++ b/src/workload_type/task.rs
@@ -20,10 +20,7 @@ impl KubeName for ReplicatedTask {
 
 impl ReplicatedTask {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "Task".to_string());
-        labels
+        self.meta.labels("Task")
     }
 }
 
@@ -74,10 +71,7 @@ impl KubeName for SingletonTask {
 }
 impl SingletonTask {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "SingletonTask".to_string());
-        labels
+        self.meta.labels("SingletonTask")
     }
 }
 impl WorkloadType for SingletonTask {

--- a/src/workload_type/worker.rs
+++ b/src/workload_type/worker.rs
@@ -12,10 +12,7 @@ pub struct ReplicatedWorker {
 
 impl ReplicatedWorker {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "Worker".to_string());
-        labels
+        self.meta.labels("Worker")
     }
 }
 
@@ -66,10 +63,7 @@ pub struct SingletonWorker {
 
 impl SingletonWorker {
     fn labels(&self) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.meta.name.clone());
-        labels.insert("workload-type".to_string(), "SingletonWorker".to_string());
-        labels
+        self.meta.labels("SingletonWorker")
     }
 }
 

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -38,15 +38,15 @@ pub struct WorkloadMetadata {
 }
 
 impl WorkloadMetadata {
-    fn labels(&self, workload_type: &str) -> BTreeMap<String, String> {
+    pub fn labels(&self, workload_type: &str) -> BTreeMap<String, String> {
         let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.name.clone());
+        labels.insert("app.kubernetes.io/name".to_string(), self.name.clone());
         labels.insert("workload-type".to_string(), workload_type.to_string());
         labels
     }
     pub fn select_labels(&self) -> BTreeMap<String, String> {
         let mut labels = BTreeMap::new();
-        labels.insert("app".to_string(), self.name.clone());
+        labels.insert("app.kubernetes.io/name".to_string(), self.name.clone());
         labels
     }
 


### PR DESCRIPTION
Also follows the SIG Apps standard labels convention. See https://helm.sh/docs/chart_best_practices/#labels-and-annotations for a list of those labels and descriptions.

closes #261

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>