### PR TITLE
fix: attach annotations to DeploymentBuilder

### DIFF
--- a/src/workload_type/service.rs
+++ b/src/workload_type/service.rs
@@ -60,7 +60,9 @@ impl WorkloadType for ReplicatedService {
         self.meta.create_config_maps("Service")?;
 
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;
 
@@ -73,7 +75,9 @@ impl WorkloadType for ReplicatedService {
     fn modify(&self) -> InstigatorResult {
         //TODO update config_map
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(
                 self.meta.client.clone(),
@@ -133,7 +137,9 @@ impl WorkloadType for SingletonService {
 
         // Create deployment
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .replicas(1)
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;

--- a/src/workload_type/worker.rs
+++ b/src/workload_type/worker.rs
@@ -31,7 +31,9 @@ impl WorkloadType for ReplicatedWorker {
         self.meta.create_config_maps("Worker")?;
 
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;
 
@@ -40,7 +42,9 @@ impl WorkloadType for ReplicatedWorker {
     fn modify(&self) -> InstigatorResult {
         //TODO update config_map
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(
                 self.meta.client.clone(),
@@ -85,7 +89,9 @@ impl WorkloadType for SingletonWorker {
         self.meta.create_config_maps("SingletonWorker")?;
 
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;
 
@@ -94,7 +100,9 @@ impl WorkloadType for SingletonWorker {
     fn modify(&self) -> InstigatorResult {
         //TODO update config_map
         DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
             .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
             .owner_ref(self.meta.owner_ref.clone())
             .do_request(
                 self.meta.client.clone(),

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -447,6 +447,7 @@ mod test {
         annotations.insert("key1".to_string(), "val1".to_string());
         annotations.insert("key2".to_string(), "val2".to_string());
         let deployment = DeploymentBuilder::new("test".into(), skeleton_component())
+            .parameter_map(BTreeMap::new())
             .labels(skeleton_labels())
             .annotations(Some(annotations))
             .replicas(3)


### PR DESCRIPTION
This fixes an issue where annotations were not being passed along to the Deployment object.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>