### PR TITLE
modified the Makefile to allow user to set image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REPO=hydraoss/scylla
-TAG=latest
+REPO = hydraoss/scylla
+TAG ?= latest
 
 .PHONY: build
 build:


### PR DESCRIPTION
This this tag, you can `TAG=0.7.0 make docker-build` and have Docker tag the image with the given $TAG.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>