### PR TITLE
fix(README): fix instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ensure you have a Kubernetes cluster.
 helm install scylla ./charts/scylla --wait
 ```
 
-2. Install NGINX ingress on your cluster. Currently, Scylla does have any opinions on how to accomplish tasks but rather leverages existing components.
+2. Install NGINX ingress on your cluster. Currently, Scylla doesn't have any opinions on how to accomplish tasks but rather leverages existing components.
 
 ```bash
 helm install nginx-ingress stable/nginx-ingress


### PR DESCRIPTION
This PR fixes up a few things in the README:

- removes any trailing whitespace from paragraphs
- removes leading whitespace from code blocks (they're unnecessary)
- fixes an issue with the `helm install` command for the nginx-ingress chart (missing release name argument)
- capitalizes NGINX as a proper noun
- further clarifies what is installed when you `kubectl apply` first-app-config.yaml, hopefully illustrating to the user what is the expected outcome of that command
- explains what the user should see when they hit the public endpoint for the ingress route.

closes #289 

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>