### PR TITLE
docs: change to OAM from Hydra

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,13 +1,13 @@
 # Frequently Asked Questions (FAQ)
 
-## What is the difference between Hydra and Scylla?
+## What is the difference between Open Application Model and Scylla?
 
-*Hydra* is a specification for describing applications.
-*Scylla* is an implementation of the Hydra specification. Scylla runs on Kubernetes, though Hydra can be implemented on non-Kubernetes platforms.
+*Open Application Model* is a specification for describing applications.
+*Scylla* is an implementation of the Open Application Model specification. Scylla runs on Kubernetes, though Open Application Model can be implemented on non-Kubernetes platforms.
 
-## What do Hydra and Scylla add to the cloud native landscape?
+## What do Open Application Model and Scylla add to the cloud native landscape?
 
-Hydra is designed to introduce separation of concerns (SoC) into Kubernetes.
+Open Application Model is designed to introduce separation of concerns (SoC) into Kubernetes.
 
 In Kubernetes today, developer information is freely intermingled with operator information. We wanted to create a way to distinguish between these two rolls so that developers could deliver an artifact that describes their microservice, and operators could apply another artifact that configures and instantiates that microservice.
 
@@ -17,17 +17,17 @@ In the hydra model, a `ComponentSchematic` describes a developer's view of a mic
 
 We do not believe we are trying to solve the same problem as Knative.
 
-## Can I use Hydra/Scylla to deploy existing applications?
+## Can I use Open Application Model/Scylla to deploy existing applications?
 
-You can describe existing applications as Hydra applications. See our [migration guide](migrating.md).
+You can describe existing applications as Open Application Model applications. See our [migration guide](migrating.md).
 
 ## How does this compare to Helm or Kompose?
 
 Helm is a package manager for Kubernetes, and provides a way to package and distribute Kubernetes applications.
 
-Hydra is just an application model that, thanks to Scylla, runs on Kubernetes. You can bundle your Hydra applications as Helm charts and deploy them using Helm.
+Open Application Model is just an application model that, thanks to Scylla, runs on Kubernetes. You can bundle your Open Application Model applications as Helm charts and deploy them using Helm.
 
-Kompose is a tool for manipulating Kubernetes YAML documents. It is also compatible with Hydra/Scylla.
+Kompose is a tool for manipulating Kubernetes YAML documents. It is also compatible with Open Application Model/Scylla.
 
 ## Can I write my own traits?
 
@@ -37,8 +37,8 @@ If you write a custom trait and integrate it with Scylla, consider opening a pul
 
 ## Can I write my own scopes?
 
-Currently, no. Scopes are fixed according to the Hydra spec.
+Currently, no. Scopes are fixed according to the Open Application Model spec.
 
-## Does Scylla support "extended workload types" as described in the Hydra specification
+## Does Scylla support "extended workload types" as described in the Open Application Model specification
 
 No. That section of the specification is a draft, and we are not yet supporting it.

--- a/docs/how-to/migrating.md
+++ b/docs/how-to/migrating.md
@@ -1,6 +1,6 @@
 # Migrating Kubernetes Resources to Scylla
 
-This document explains, at a high level, how to represent your Kubernetes applications using the Hydra specification.
+This document explains, at a high level, how to represent your Kubernetes applications using the Open Application Model specification.
 
 ## Terms
 
@@ -8,7 +8,7 @@ The terms here are described elsewhere, particularly in the [specification](http
 
 - Component: A component describes a particular workload (or microservice) that can be deployed.
 - Component Instance: A particular instance of a component. If one Component is deployed in two Application Configurations, it will create two Component Instances, each of which is managed by its Application Configuration
-- Workload type: Hydra describes the basic behavior of a Component using workload types. There are 6 core workload types:
+- Workload type: Open Application Model describes the basic behavior of a Component using workload types. There are 6 core workload types:
   - SingletonService: This service listens on a network interface. Only one instance of the component's pod can run at a time.
   - ReplicableService: This service listens on a network interface, but multiple replicas of the component's pod can be running concurrently.
   - SingletonTask: This component only runs for a short period of time (it is not a daemon). It does not listen on a network interface. And at any given time, only one of these may run per application.
@@ -21,17 +21,17 @@ The terms here are described elsewhere, particularly in the [specification](http
 
 ## Separation of Concerns
 
-One of the questions we occasionally hear from seasoned Kubernetes developers is _What do I gain from Hydra?_. To be clear, part of the design of Hydra was to make it easier for developers to work with Kubernetes without needing to understand the operational aspects of Kubernetes. But the real virtue we see in Hydra is its separation of concerns.
+One of the questions we occasionally hear from seasoned Kubernetes developers is _What do I gain from Open Application Model?_. To be clear, part of the design of Open Application Model was to make it easier for developers to work with Kubernetes without needing to understand the operational aspects of Kubernetes. But the real virtue we see in Open Application Model is its separation of concerns.
 
 Today's Kubernetes objects are built to _describe a concept_. A Deployment describes a replicable service that can have certain rollout strategies applied.
 
-But Hydra attempts to start with a different premise, and then describe things accordingly:
+But Open Application Model attempts to start with a different premise, and then describe things accordingly:
 
 > Cloud Native Applications have responsibilities described by three different roles: Developers, Application Operators, and Infrastructure Operators.
 
 Each of these roles has a different job, and different concerns. A developer is responsible for producing a runnable workload. An application operator is responsible for executing an application inside of Kubernetes. An infrastructure operator is responsible for configuring and running Kubernetes itself.
 
-In our view, the developer is responsible for creating and maintaining Components. The application operator takes responsibility for the Application Configuration. And the infrastructure operator runs Scylla, and decides how Hydra's Traits and Scopes are used in practice. And Scylla's job is to take these various inputs and transform them into underlying Kubernetes types.
+In our view, the developer is responsible for creating and maintaining Components. The application operator takes responsibility for the Application Configuration. And the infrastructure operator runs Scylla, and decides how Open Application Model's Traits and Scopes are used in practice. And Scylla's job is to take these various inputs and transform them into underlying Kubernetes types.
 
 ## Workflow
 
@@ -47,7 +47,7 @@ Likewise, when Application Configurations are modified or deleted, Scylla will r
 
 ## Converting a Kubernetes Application to Scylla
 
-A major goal of the Hydra specification is to separate operational concerns from developer concerns. So a `ComponentSchematic` describes a component from a developer's view, while an `ApplicationConfiguration` creates instances of Components, and attaches configuration data to them.
+A major goal of the Open Application Model specification is to separate operational concerns from developer concerns. So a `ComponentSchematic` describes a component from a developer's view, while an `ApplicationConfiguration` creates instances of Components, and attaches configuration data to them.
 
 To convert a Kubernetes application to Scylla, you can follow these steps:
 
@@ -55,7 +55,7 @@ To convert a Kubernetes application to Scylla, you can follow these steps:
     - A `Deployment` or `ReplicaSet` can be converted to one of `SingletonService`, `ReplicableService`, `SingletonWorker`, or `ReplicableWorker` depending on its runtime requirements
     - A `Job` can be converted to one of `SingletonTask` or `ReplicableTask`
     - A `Pod` can be converted to `SingletonService` or `SingletonWorker`
-    - At this time, `StatefulSets` and `DaemonSets` do not have Hydra equivalents.
+    - At this time, `StatefulSets` and `DaemonSets` do not have Open Application Model equivalents.
     - Expose parameters. For example, if your container image takes `FOO` as an environment variable, you may expose a parameter that allows an operator to set `FOO`'s value.
 2. Create an `ApplicationConfiguration` YAML file
 3. Compose your application by listing which Components (defined above) should be instantiated as part of your application.

--- a/docs/how-to/using_scylla.md
+++ b/docs/how-to/using_scylla.md
@@ -6,7 +6,7 @@ If you are just getting started and want a quick entry point to Scylla, you may 
 
 ## Four Concepts with One Action
 
-Scylla is a reference implementation of the [Hydra specification](https://github.com/microsoft/hydra-spec) for Kubernetes. So before using Scylla, you may need to understand some concepts of Hydra. If you're interested to learn more, you can directly read the [Hydra specification](https://github.com/microsoft/hydra-spec). 
+Scylla is a reference implementation of the [Open Application Model specification](https://github.com/microsoft/hydra-spec) for Kubernetes. So before using Scylla, you may need to understand some concepts of Open Application Model. If you're interested to learn more, you can directly read the [Open Application Model specification](https://github.com/microsoft/hydra-spec). 
 
 ### Component schematics
  
@@ -60,7 +60,7 @@ Use `kubectl get component <component-name> -o yaml` to find details of the comp
 
 A workload type is an indicator to the runtime as to how it should execute the given workload. In other words, it provides a single field by which the developer can indicate to the runtime how they intend for this component to be executed.
 
-The Hydra Spec defines two broad categories of workloads:
+The Open Application Model Spec defines two broad categories of workloads:
 
 * Core workload types
 * Extended workload types
@@ -80,7 +80,7 @@ A trait can be any application configuration of a distributed application that a
 
 Traits can be selected by the application operator as they are implemented as CRDs predefined by the platform operator.
 
-Currently we only have three traits but have plans add more in the near future. We encourage submitting PRs on Hydra if you feel like you have a good idea for a trait that could be broadly used by others. 
+Currently we only have three traits but have plans add more in the near future. We encourage submitting PRs on Open Application Model if you feel like you have a good idea for a trait that could be broadly used by others. 
 
 `kubectl get traits` returns the traits the platform supports. 
 

--- a/docs/how-to/workloads.md
+++ b/docs/how-to/workloads.md
@@ -16,7 +16,7 @@ Now Scylla has all the core workload type, they are as belows:
 A Service is used for long-running, scalable workload that have a network endpoint with a stable name to receive network traffic for the component as a whole. 
 Common use cases include web applications and services that expose APIs. 
 
-The name is a little confusing with Kubernetes Service, so maybe we'll name it by Server or ReplicabeService, it's all depending on the Hydra Spec.
+The name is a little confusing with Kubernetes Service, so maybe we'll name it by Server or ReplicabeService, it's all depending on the Open Application Model Spec.
 
 The Service Workload in Scylla is implemented by a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) binding with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -116,7 +116,7 @@ $ helm delete scylla
 
 This will leave the CRDs intact.
 
-**NOTE: When you delete the CRDs, it will delete everything touching Hydra from configurations to secrets.**
+**NOTE: When you delete the CRDs, it will delete everything touching Open Application Model from configurations to secrets.**
 
 ## Installing Implementations for Traits
 


### PR DESCRIPTION
I decided to do renaming in chunks, as it's just too much to do in one go. So this chunk renamed `Hydra` to `Open Application Model` in the docs.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>