### PR TITLE
setup docker hub secret as env in action workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,4 +13,6 @@ jobs:
       - name: Build Container Images
         run: make docker-build-cx
       - name: Publish Container Images
+        env:
+          hydraoss_secret: ${{ secrets.hydraoss }}
         run: make docker-publish

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ docker-build-cx:
 	docker build -t $(REPO)-amd64:$(TAG) .
 
 docker-publish: docker-build-cx
+	docker login -u hydraoss -p ${hydraoss_secret}
 	docker push $(REPO)-amd64:$(TAG)
 	docker push $(REPO)-arm64:$(TAG)
 	docker manifest create $(REPO):$(TAG) $(REPO)-amd64:$(TAG) $(REPO)-arm64:$(TAG)


### PR DESCRIPTION
I have setup secret as [the instruction](https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables) said, and make it available in workflow.

I have tested in my own repo.

fixes https://github.com/microsoft/scylla/issues/153