### PR TITLE
change name volumeMounter to volume-mounter

### DIFF
--- a/charts/scylla/templates/traits.yaml
+++ b/charts/scylla/templates/traits.yaml
@@ -65,7 +65,7 @@ spec:
 apiVersion: core.hydra.io/v1alpha1
 kind: Trait
 metadata:
-  name: volumeMounter
+  name: volume-mounter
 spec:
   appliesTo:
     - core.hydra.io/v1alpha1.Service

--- a/docs/concepts/traits.md
+++ b/docs/concepts/traits.md
@@ -188,7 +188,7 @@ spec:
     - name: server-with-volume-v1
       instanceName: example-server-with-volume
       traits:
-        - name: volumeMounter
+        - name: volume-mounter
           parameterValues:
             - name: volumeName
               value: myvol
@@ -196,7 +196,7 @@ spec:
               value: default
 ```
 
-The `volumeMounter` trait ensures that a PVC is created with the given name (`myvol`) using the given storage class (`default`). Typically, the `volumeName` should match the `resources.volumes[].name` field from the `ComponentSchematic`. Thus `myvol` above will match the volume declared in the `volumes` section of `server-with-volume-v1`.
+The `volume-mounter` trait ensures that a PVC is created with the given name (`myvol`) using the given storage class (`default`). Typically, the `volumeName` should match the `resources.volumes[].name` field from the `ComponentSchematic`. Thus `myvol` above will match the volume declared in the `volumes` section of `server-with-volume-v1`.
 
 When this request is processed by Scylla, it will first create the Kubernetes PVC named `myvol` and then create a Kubernetes pod that attaches that PVC as a `volumeMount`.
 

--- a/docs/developer/writing_a_trait.md
+++ b/docs/developer/writing_a_trait.md
@@ -15,7 +15,7 @@ kind: Trait
 metadata:
   # Define the name of the trait. This will be the reference by which ApplicationConfigurations
   # reference this trait.
-  name: volumeMounter
+  name: volume-mounter
 spec:
   # The appliesTo field lists all of the Workload Types that this trait can be added to.
   # In this case, all of the core workload types are supported.
@@ -97,7 +97,7 @@ pub use crate::schematic::traits::manual_scaler::ManualScaler;
 // Our new trait
 mod volume_mounter;
 pub use crate::schematic::traits::volume_mounter::VolumeMounter;
-pub const VOLUME_MOUNTER: &str = "volumeMounter";
+pub const VOLUME_MOUNTER: &str = "volume-mounter";
 
 // Then more code...
 

--- a/examples/volumes.yaml
+++ b/examples/volumes.yaml
@@ -25,7 +25,7 @@ spec:
     - name: server-with-volume-v1
       instanceName: example-server-with-volume
       traits:
-        - name: volumeMounter
+        - name: volume-mounter
           parameterValues:
             - name: volumeName
               value: myvol

--- a/src/schematic/traits.rs
+++ b/src/schematic/traits.rs
@@ -30,7 +30,7 @@ mod util_test;
 pub const INGRESS: &str = "ingress";
 pub const AUTOSCALER: &str = "autoscaler";
 pub const MANUAL_SCALER: &str = "manual-scaler";
-pub const VOLUME_MOUNTER: &str = "volumeMounter";
+pub const VOLUME_MOUNTER: &str = "volume-mounter";
 pub const EMPTY: &str = "empty";
 
 /// Trait describes Hydra traits.


### PR DESCRIPTION
Fix for a bug @hongchaodeng noticed.

I mistakenly named the trait `volumeMounter`, which is not a valid Kubernetes name. This caused the Helm chart install to fail.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>