### PR TITLE
rename all non-function occurances of Scylla to Rudr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Building from Source
 
-This section goes over how to build the source code for Scylla. 
+This section goes over how to build the source code for Rudr. 
 
 ### Prerequisites 
 
@@ -31,9 +31,9 @@ kubectl apply -f charts/scylla/crds/scopes.yaml
 kubectl apply -f charts/scylla/crds/traits.yaml
 ```
 - Run `cargo build`
-- To run the server: `make run`, this will run Scylla controller locally, and use the cluster by your `~/.kube/config`.
+- To run the server: `make run`, this will run Rudr controller locally, and use the cluster by your `~/.kube/config`.
 
-At this point, you will be running a local controller attached to the cluster to which your kubeconfig is pointing.
+At this point, you will be running a local controller attached to the cluster to which your `$KUBECONFIG` is pointing.
 
 To get started, define some _components_. Components are not instantiated. They are descriptions of what things can run in your cluster.
 
@@ -97,7 +97,7 @@ Like any good open source project, we use Pull Requests (PRs) to track code chan
     - All PRs require 1 review approval from a maintainer before being merged. 
 4. Reviewing/Discussion
     - All reviews will be completed using Github review tool.
-    - A "Comment" review should be used when there are questions about Scylla. This type of review does not count as approval.
+    - A "Comment" review should be used when there are questions about Rudr. This type of review does not count as approval.
     - A "Changes Requested" review indicates that changes need to be made before they will be
     merged.
     - Reviewers should update labels as needed (such as `Status: Needs rebase`).
@@ -121,7 +121,7 @@ To learn about issue types, please read the [labels](https://github.com/microsof
 ### Issue Lifecycle
 
 The issue lifecycle is mainly driven by the core maintainers, but is good information for those
-contributing to Scylla. All issue types follow the same general lifecycle.
+contributing to Rudr. All issue types follow the same general lifecycle.
 
 1. Issue creation. 
 2. Triage
@@ -140,10 +140,10 @@ contributing to Scylla. All issue types follow the same general lifecycle.
 
 ### Milestones
 
-To get an overview of the milestones that are being tracked for Scylla please visit the [Milestones](https://github.com/microsoft/hydra-spec/milestones) page. 
+To get an overview of the milestones that are being tracked for Rudr please visit the [Milestones](https://github.com/microsoft/hydra-spec/milestones) page. 
 
 ### Triaging 
 
-Each day, someone from a Open Application Model related team should act as the triager. This person will be in charge triaging new PRs and issues throughout the day. Anyone can volunteer as the triager by posting on the Slack channel or voluteering in advance during our community calls. If no one has volunteered by 10:00 AM PST, someone from Steelthread will triage. 
+Each day, someone from a Open Application Model related team should act as the triager. This person will be in charge triaging new PRs and issues throughout the day. Anyone can volunteer as the triager by posting on the Slack channel or volunteering in advance during our community calls. If no one has volunteered by 10:00 AM PST, someone from our team will triage. 
 
 Broader discussion of any issues can be raised during the bi-weekly community call. Issues might be brought into milestones, removed from milestones or moved between milestones during the call.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Cargo.toml .
 COPY Cargo.lock .
 
 # Create dummy files to build the dependencies, cargo won't build without src/main.rs and src/lib.rs
-# then remove Scylla fingerprint for following rebuild
+# then remove Rudr fingerprint for following rebuild
 RUN mkdir -p ./src/ && \
     echo 'fn main() {}' > ./src/main.rs && \
     echo '' > ./src/lib.rs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Scylla: A Kubernetes Implementation of the Open Application Model
+# Rudr: A Kubernetes Implementation of the Open Application Model
 
-Scylla is an implementation of the [Open Application Model (OAM)](https://github.com/microsoft/hydra-spec) that allow users to deploy and manage applications easily on any Kubernetes cluster with separation of concerns of application developer and operator.
+Rudr is an implementation of the [Open Application Model (OAM)](https://github.com/microsoft/hydra-spec) that allow users to deploy and manage applications easily on any Kubernetes cluster with separation of concerns of application developer and operator.
 
-**Scylla is currently in alpha. It may reflect the API or features we are vetting before inclusion into the Open App Model spec..**
+**Rudr is currently in alpha. It may reflect the API or features we are vetting before inclusion into the Open App Model spec..**
 
 ## Quickstart: Deploy an app with Ingress
 
@@ -15,13 +15,13 @@ Ensure you have a Kubernetes cluster.
 - [Elastic Kubernetes  Service](https://aws.amazon.com/quickstart/architecture/amazon-eks/)
 - [Minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/)
 
-1. Install Scylla on the cluster.
+1. Install Rudr on the cluster.
 
 ```bash
 helm install scylla ./charts/scylla --wait
 ```
 
-2. Install NGINX ingress on your cluster. Currently, Scylla doesn't have any opinions on how to accomplish tasks but rather leverages existing components.
+2. Install NGINX ingress on your cluster. Currently, Rudr doesn't have any opinions on how to accomplish tasks but rather leverages existing components.
 
 ```bash
 helm install nginx-ingress stable/nginx-ingress
@@ -58,7 +58,7 @@ The requirement to deep understand the container infrastructure has introduced t
 
 ## The approach: Let's take things one step at a time
 
-Scylla takes an incremental approach to solving the problems. The current architecture is set of plugins for Kubernetes which allows OAM specifications to be implemented and deployed on Kubernetes clusters using native APIs (and you still use kubectl!).
+Rudr takes an incremental approach to solving the problems. The current architecture is set of plugins for Kubernetes which allows OAM specifications to be implemented and deployed on Kubernetes clusters using native APIs (and you still use kubectl!).
 
 ![oar arch](./docs/media/how_oar_works.png)
 
@@ -66,7 +66,7 @@ Scylla takes an incremental approach to solving the problems. The current archit
 
 - By leveraging the Open App Model, users now have a framework to define their apps on their Kubernetes clusters.
 
-- Currently, Scylla will leverage the defined trait to accomplish the task. This gives the freedom to use whatever underlying tool the user wants while providing a trait that focuses on the functionality and not the technology. In the future, Scylla might provide a set of default technologies to provide the functionality desired by a trait.
+- Currently, Rudr will leverage the defined trait to accomplish the task. This gives the freedom to use whatever underlying tool the user wants while providing a trait that focuses on the functionality and not the technology. In the future, Rudr might provide a set of default technologies to provide the functionality desired by a trait.
 
 ## Try things out yourself
 
@@ -90,11 +90,11 @@ This project follows governance structure of numerous other open source projects
 
 ## About the Name
 
-Scylla is one of the monsters in Homer's Odyssey. Odysseus must steer his ship between Scylla and Charybdis. Scylla is sometimes portrayed as a hydra.
+Rudr is one of the monsters in Homer's Odyssey. Odysseus must steer his ship between Rudr and Charybdis. Rudr is sometimes portrayed as a hydra.
 
 ## Why Rust?
 
-On occasion, we have been asked why Scylla is written in Rust instead of Go. There is no requirement in the Kubernetes world that Kubernetes controllers be written in Go. Many languages implement the Kubernetes API and can be used for creating controllers. We decided to write Scylla in Rust because the language allows us to write Kubernetes controllers with far less code. Rust's generics make it possible to quickly and succinctly describe custom Kubernetes API resources without requiring developers to run code generators. And Rust's Kubernetes library can easily switch between Kubernetes versions with ease. We recognize that Rust might not be to everyone's taste (and neither is Go). However, we are confident that Rust is a solid choice for writing maintainable and concise Kubernetes applications.
+On occasion, we have been asked why Rudr is written in Rust instead of Go. There is no requirement in the Kubernetes world that Kubernetes controllers be written in Go. Many languages implement the Kubernetes API and can be used for creating controllers. We decided to write Rudr in Rust because the language allows us to write Kubernetes controllers with far less code. Rust's generics make it possible to quickly and succinctly describe custom Kubernetes API resources without requiring developers to run code generators. And Rust's Kubernetes library can easily switch between Kubernetes versions with ease. We recognize that Rust might not be to everyone's taste (and neither is Go). However, we are confident that Rust is a solid choice for writing maintainable and concise Kubernetes applications.
 
 ## License
 

--- a/charts/scylla/templates/NOTES.txt
+++ b/charts/scylla/templates/NOTES.txt
@@ -1,3 +1,3 @@
-Scylla is a Kubernetes controller to manage Configuration CRDs.
+Rudr is a Kubernetes controller to manage Configuration CRDs.
 
 It has been successfully installed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,18 @@
-# Scylla Documentation
+# Rudr Documentation
 
 # Table of Contents
 
-## 1. [Install Scylla](./setup/install.md)
+## 1. [Install Rudr](./setup/install.md)
 
 ## 2. [Quickstart](./quickstart/quickstart.md)
 ## 3. How-To's
-* ### [Use Scylla](./how-to/using_scylla.md) - Learn how to use Scylla.
+* ### [Use Rudr](./how-to/using_scylla.md) - Learn how to use Rudr.
 * ### [Use Core Workloads](./how-to/workloads.md) - Learn how to use core workload type.
 * ### [Migrate existing Kubernetes resources](./how-to/migrating.md) - Learn how to migrate existing K8s resources
 
 ## 4. Tutorials 
 
 ## 5. Concepts
-* ### [Traits](./concepts/traits.md) - Learn in more depth about traits in Scylla.
+* ### [Traits](./concepts/traits.md) - Learn in more depth about traits in Rudr.
 
 ## 6. [FAQ](./faq.md)

--- a/docs/concepts/traits.md
+++ b/docs/concepts/traits.md
@@ -1,8 +1,8 @@
 # Traits
 
-A [*trait*](https://github.com/microsoft/hydra-spec/blob/master/5.traits.md) represents a piece of add-on functionality that attaches to a component instance. Traits augment components with additional operational features such as traffic routing rules (including load balancing policy, network ingress routing, circuit breaking, rate limiting), auto-scaling policies, upgrade strategies, and more. As such, traits represent features of the system that are operational concerns, as opposed to developer concerns. In terms of implementation details, traits are Scylla-defined Kubernetes CRDs.
+A [*trait*](https://github.com/microsoft/hydra-spec/blob/master/5.traits.md) represents a piece of add-on functionality that attaches to a component instance. Traits augment components with additional operational features such as traffic routing rules (including load balancing policy, network ingress routing, circuit breaking, rate limiting), auto-scaling policies, upgrade strategies, and more. As such, traits represent features of the system that are operational concerns, as opposed to developer concerns. In terms of implementation details, traits are Rudr-defined Kubernetes CRDs.
 
-Currently, Scylla supports the following traits:
+Currently, Rudr supports the following traits:
 
  - [Manual Scaler](#manual-scaler-trait)
  - [Autoscaler](#autoscaler-trait)
@@ -39,9 +39,9 @@ You can assign a trait to a component by specifying its **`name`** (as listed in
 
 ## Supported traits
 
-Currently Scylla supports three traits (with more rolling out in the future, including support for defining custom traits). In order provide maximum flexibility to [Infrastructure operators](https://github.com/microsoft/hydra-spec/blob/master/2.overview_and_terminology.md#roles-and-responsibilities), however, Scylla does not install default implementations for some of these these traits. Specifically, the *Autoscaler* and *Ingress* traits require you to select and install a Kubernetes controller before you can use them in your Scylla application, since they map to primitive Kubernetes features that can be fulfilled by different controllers. You can search for implementations for your traits at [Helm Hub](https://hub.helm.sh/).
+Currently Rudr supports three traits (with more rolling out in the future, including support for defining custom traits). In order provide maximum flexibility to [Infrastructure operators](https://github.com/microsoft/hydra-spec/blob/master/2.overview_and_terminology.md#roles-and-responsibilities), however, Rudr does not install default implementations for some of these these traits. Specifically, the *Autoscaler* and *Ingress* traits require you to select and install a Kubernetes controller before you can use them in your Rudr application, since they map to primitive Kubernetes features that can be fulfilled by different controllers. You can search for implementations for your traits at [Helm Hub](https://hub.helm.sh/).
 
-Here's how to get info on the traits supported on your Scylla installation.
+Here's how to get info on the traits supported on your Rudr installation.
 
 **List supported traits**:
 
@@ -176,7 +176,7 @@ spec:
               ephemeral: false
 ```
 
-In the Kubernetes implementation of OAM, a Persistent Volume Claim (PVC) is used to satisfy the non-ephemeral case. However, by default Scylla does not create this PVC automatically. A trait must be applied that will indicate how the PVC is created:
+In the Kubernetes implementation of OAM, a Persistent Volume Claim (PVC) is used to satisfy the non-ephemeral case. However, by default Rudr does not create this PVC automatically. A trait must be applied that will indicate how the PVC is created:
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
@@ -198,6 +198,6 @@ spec:
 
 The `volume-mounter` trait ensures that a PVC is created with the given name (`myvol`) using the given storage class (`default`). Typically, the `volumeName` should match the `resources.volumes[].name` field from the `ComponentSchematic`. Thus `myvol` above will match the volume declared in the `volumes` section of `server-with-volume-v1`.
 
-When this request is processed by Scylla, it will first create the Kubernetes PVC named `myvol` and then create a Kubernetes pod that attaches that PVC as a `volumeMount`.
+When this request is processed by Rudr, it will first create the Kubernetes PVC named `myvol` and then create a Kubernetes pod that attaches that PVC as a `volumeMount`.
 
 Attaching PVCs to Pods _may take extra time_, as the underlying system must first provision storage.

--- a/docs/developer/writing_a_trait.md
+++ b/docs/developer/writing_a_trait.md
@@ -1,8 +1,8 @@
 # Writing a Trait
 
-This guide explains how to write a trait for Scylla, using the VolumeMounter trait as an example.
+This guide explains how to write a trait for Rudr, using the VolumeMounter trait as an example.
 
-> Note: The process for adding a new trait is currently more difficult than it needs to be. In future versions of Scylla, we will be streamlining this process considerably.
+> Note: The process for adding a new trait is currently more difficult than it needs to be. In future versions of Rudr, we will be streamlining this process considerably.
 
 ## Step 1: Defining the Trait Resource
 
@@ -279,7 +279,7 @@ In a nutshell, all we are doing above is declaring how to add, modify, and remov
 
 ## Registering the Trait with the Trait Manager
 
-Now that we have our trait written, the last step is to register it with the trait manager. This process tells Scylla to handle requests for our new trait.
+Now that we have our trait written, the last step is to register it with the trait manager. This process tells Rudr to handle requests for our new trait.
 
 The `src/instigator.rs` file has the trait manager. Find `impl TraitManager` and edit the `load_trait` function:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,11 +1,11 @@
 # Frequently Asked Questions (FAQ)
 
-## What is the difference between Open Application Model and Scylla?
+## What is the difference between Open Application Model and Rudr?
 
 *Open Application Model* is a specification for describing applications.
-*Scylla* is an implementation of the Open Application Model specification. Scylla runs on Kubernetes, though Open Application Model can be implemented on non-Kubernetes platforms.
+*Rudr* is an implementation of the Open Application Model specification. Rudr runs on Kubernetes, though Open Application Model can be implemented on non-Kubernetes platforms.
 
-## What do Open Application Model and Scylla add to the cloud native landscape?
+## What do Open Application Model and Rudr add to the cloud native landscape?
 
 Open Application Model is designed to introduce separation of concerns (SoC) into Kubernetes.
 
@@ -17,7 +17,7 @@ In the hydra model, a `ComponentSchematic` describes a developer's view of a mic
 
 We do not believe we are trying to solve the same problem as Knative.
 
-## Can I use Open Application Model/Scylla to deploy existing applications?
+## Can I use Open Application Model/Rudr to deploy existing applications?
 
 You can describe existing applications as Open Application Model applications. See our [migration guide](migrating.md).
 
@@ -25,20 +25,20 @@ You can describe existing applications as Open Application Model applications. S
 
 Helm is a package manager for Kubernetes, and provides a way to package and distribute Kubernetes applications.
 
-Open Application Model is just an application model that, thanks to Scylla, runs on Kubernetes. You can bundle your Open Application Model applications as Helm charts and deploy them using Helm.
+Open Application Model is just an application model that, thanks to Rudr, runs on Kubernetes. You can bundle your Open Application Model applications as Helm charts and deploy them using Helm.
 
-Kompose is a tool for manipulating Kubernetes YAML documents. It is also compatible with Open Application Model/Scylla.
+Kompose is a tool for manipulating Kubernetes YAML documents. It is also compatible with Open Application Model/Rudr.
 
 ## Can I write my own traits?
 
-Currently, all traits are built into Scylla. However, our plan is to make it possible for custom traits to be written and deployed into a Scylla cluster.
+Currently, all traits are built into Rudr. However, our plan is to make it possible for custom traits to be written and deployed into a Rudr cluster.
 
-If you write a custom trait and integrate it with Scylla, consider opening a pull request. We are interested in adding more traits.
+If you write a custom trait and integrate it with Rudr, consider opening a pull request. We are interested in adding more traits.
 
 ## Can I write my own scopes?
 
 Currently, no. Scopes are fixed according to the Open Application Model spec.
 
-## Does Scylla support "extended workload types" as described in the Open Application Model specification
+## Does Rudr support "extended workload types" as described in the Open Application Model specification
 
 No. That section of the specification is a draft, and we are not yet supporting it.

--- a/docs/how-to/migrating.md
+++ b/docs/how-to/migrating.md
@@ -1,4 +1,4 @@
-# Migrating Kubernetes Resources to Scylla
+# Migrating Kubernetes Resources to Rudr
 
 This document explains, at a high level, how to represent your Kubernetes applications using the Open Application Model specification.
 
@@ -31,25 +31,25 @@ But Open Application Model attempts to start with a different premise, and then 
 
 Each of these roles has a different job, and different concerns. A developer is responsible for producing a runnable workload. An application operator is responsible for executing an application inside of Kubernetes. An infrastructure operator is responsible for configuring and running Kubernetes itself.
 
-In our view, the developer is responsible for creating and maintaining Components. The application operator takes responsibility for the Application Configuration. And the infrastructure operator runs Scylla, and decides how Open Application Model's Traits and Scopes are used in practice. And Scylla's job is to take these various inputs and transform them into underlying Kubernetes types.
+In our view, the developer is responsible for creating and maintaining Components. The application operator takes responsibility for the Application Configuration. And the infrastructure operator runs Rudr, and decides how Open Application Model's Traits and Scopes are used in practice. And Rudr's job is to take these various inputs and transform them into underlying Kubernetes types.
 
 ## Workflow
 
-Traits and Scopes are provided by Scylla. You can list them with `kubectl get traits` and `kubectl get scopes`.
+Traits and Scopes are provided by Rudr. You can list them with `kubectl get traits` and `kubectl get scopes`.
 
 You may install your own components.
 
-To create a new Scylla application, create an `ApplicationConfiguration` YAML file and specify the components, traits, scopes, and parameters.
+To create a new Rudr application, create an `ApplicationConfiguration` YAML file and specify the components, traits, scopes, and parameters.
 
-Scylla watches for new Application Configurations. When one is created, Scylla will read it, load the component, trait, and scope definitions, and then create new resources in Kubernetes.
+Rudr watches for new Application Configurations. When one is created, Rudr will read it, load the component, trait, and scope definitions, and then create new resources in Kubernetes.
 
-Likewise, when Application Configurations are modified or deleted, Scylla will respond to those events, managing the resources for those components, scopes, and traits.
+Likewise, when Application Configurations are modified or deleted, Rudr will respond to those events, managing the resources for those components, scopes, and traits.
 
-## Converting a Kubernetes Application to Scylla
+## Converting a Kubernetes Application to Rudr
 
 A major goal of the Open Application Model specification is to separate operational concerns from developer concerns. So a `ComponentSchematic` describes a component from a developer's view, while an `ApplicationConfiguration` creates instances of Components, and attaches configuration data to them.
 
-To convert a Kubernetes application to Scylla, you can follow these steps:
+To convert a Kubernetes application to Rudr, you can follow these steps:
 
 1. Describe your workloads (microservices) as Components.
     - A `Deployment` or `ReplicaSet` can be converted to one of `SingletonServer`, `Server`, `SingletonWorker`, or `ReplicableWorker` depending on its runtime requirements
@@ -61,7 +61,7 @@ To convert a Kubernetes application to Scylla, you can follow these steps:
 3. Compose your application by listing which Components (defined above) should be instantiated as part of your application.
     - For each component...
         1. Determine if any Traits need to be applied
-            - `Ingress` and `HorizontalPodAutoscaler` have direct equivalents in Scylla, using the `Ingress` and `Autoscaler` traits
+            - `Ingress` and `HorizontalPodAutoscaler` have direct equivalents in Rudr, using the `Ingress` and `Autoscaler` traits
             - Use `kubectl get traits` to see what other traits may apply
         2. Determine what Scopes need to be applied
             - Use `kubectl get scopes` to see what scopes may apply

--- a/docs/how-to/using_scylla.md
+++ b/docs/how-to/using_scylla.md
@@ -1,18 +1,18 @@
-# Using Scylla
+# Using Rudr
 
-This guide explains the basics of using Scylla to install applications on your Kubernetes cluster. It assumes that you have already [installed Scylla](install.md).
+This guide explains the basics of using Rudr to install applications on your Kubernetes cluster. It assumes that you have already [installed Rudr](install.md).
 
-If you are just getting started and want a quick entry point to Scylla, you may wish to begin with the [Quickstart Guide](quickstart.md) - it covers how to use Scylla and install one simple example application.
+If you are just getting started and want a quick entry point to Rudr, you may wish to begin with the [Quickstart Guide](quickstart.md) - it covers how to use Rudr and install one simple example application.
 
 ## Four Concepts with One Action
 
-Scylla is a reference implementation of the [Open Application Model specification](https://github.com/microsoft/hydra-spec) for Kubernetes. So before using Scylla, you may need to understand some concepts of Open Application Model. If you're interested to learn more, you can directly read the [Open Application Model specification](https://github.com/microsoft/hydra-spec). 
+Rudr is a reference implementation of the [Open Application Model specification](https://github.com/microsoft/hydra-spec) for Kubernetes. So before using Rudr, you may need to understand some concepts of Open Application Model. If you're interested to learn more, you can directly read the [Open Application Model specification](https://github.com/microsoft/hydra-spec). 
 
 ### Component schematics
  
 The component schematics is where developers declare the operational characteristics of the code they deliver in infrastructure neutral terms.
 
-In Scylla, the schema of component schematics is something like below:
+In Rudr, the schema of component schematics is something like below:
 
 ```yaml
 apiVersion: core.hydra.io/v1alpha1
@@ -43,7 +43,7 @@ In the example, we can see that there are five fields in spec:
 
 1. workload type used to declare which kind of workload pattern you will use; we will explain this further in the following content.
 2. os and arch are used to specify which runtime the component can run. These two values can be omitted causing the os to default to linux and the arch to default to amd64.
-3. containers are almost the same with kubernetes container spec. However, some differences are we allow to bind the config here. The configs in container are implemented using the Kubernetes ConfigMap in Scylla. In this example, we will bind to config as a volume to the pod.
+3. containers are almost the same with kubernetes container spec. However, some differences are we allow to bind the config here. The configs in container are implemented using the Kubernetes ConfigMap in Rudr. In this example, we will bind to config as a volume to the pod.
 4. parameters can be used as reference values in container spec, such as environment values.
 
 The only field we missed in the example is workload settings. This field is used to declare values for non-container settings that should be passed to the workload runtime.
@@ -65,7 +65,7 @@ The Open Application Model Spec defines two broad categories of workloads:
 * Core workload types
 * Extended workload types
 
-Within these these two categories of workloads, there are several workload types. A non-exhaustive list of workload types might include a server, singleton server, and task. Currently Scylla only has all of the six core workload types, you can find more details in [workloads documentation](workloads.md).
+Within these these two categories of workloads, there are several workload types. A non-exhaustive list of workload types might include a server, singleton server, and task. Currently Rudr only has all of the six core workload types, you can find more details in [workloads documentation](workloads.md).
 
 It's important to understand that workload types don't have any CRDs. They are simply just a field within a component. Platform users can't define custom workload types. 
 They can only choose workload types predefined by the platform runtime.  
@@ -92,7 +92,7 @@ You can find more information in [traits documentation](traits.md).
 
 Application scopes are used to group components together into logical units that are bound by a common dependency. An example of this is a network scope. Even if you deploy 5 components within an application configuration, perhaps you want three of those components deployed in one network and the other two deployed in a separate network. To achieve this behavior, you could tag the former with network scope A  and the later with network scope B in the application configuration.
 
-Scylla will soon implement health and network application scopes; however currently we don't have any application scopes implemented.
+Rudr will soon implement health and network application scopes; however currently we don't have any application scopes implemented.
 
 Application scopes are also concept like component and trait. 
 
@@ -122,7 +122,7 @@ spec:
             value: 1
 ```
 
-While you can't see an implementation of scopes here in this example, in future Scylla versions it will contain components, traits and application scopes.
+While you can't see an implementation of scopes here in this example, in future Rudr versions it will contain components, traits and application scopes.
 The traits are also optional. The only hard requirement is that at least one component or application scope is required.
 
 The component, traits and application scopes here are all references. You must confirm that the platform has these three kind of resources that you defined in the configuration file.

--- a/docs/how-to/workloads.md
+++ b/docs/how-to/workloads.md
@@ -1,6 +1,6 @@
 # Workloads
 
-Now Scylla has all the core workload type, they are as belows: 
+Now Rudr has all the core workload type, they are as belows: 
 
 |Name|Type|Service endpoint|Replicable|Daemonized|
 |-|-|-|-|-|
@@ -16,7 +16,7 @@ Now Scylla has all the core workload type, they are as belows:
 A Server is used for long-running, scalable workload that have a network endpoint with a stable name to receive network traffic for the component as a whole. 
 Common use cases include web applications and services that expose APIs.
 
-The Server workload in Scylla is implemented by a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) binding with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
+The Server workload in Rudr is implemented by a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) binding with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 
 So you can use Ingress, Autoscaler or Manual Scaler trait binding with it in a configuration.
 
@@ -24,7 +24,7 @@ So you can use Ingress, Autoscaler or Manual Scaler trait binding with it in a c
 
 A Singleton Server is a special kind of Server, just like the name pointed out, the only difference is this is a singleton.
 
-The Singleton Server in Scylla is implemented by a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) binding with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
+The Singleton Server in Rudr is implemented by a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) binding with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 
 > Operators should not attempt to modify the `replicaCount` on a `Deployment` created by a `SingletonServer`.
 
@@ -36,7 +36,7 @@ Of course binding an Ingress trait is OK just like the Server Workload.
 
 A Task is used to run code or a script to completion. Commonly used to run cron jobs or one-time highly parallelizable tasks that exit and free up resources upon completion. 
 
-The Task in Scylla is implemented by a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/), you can use  Autoscaler or Manual Scaler trait with it.
+The Task in Rudr is implemented by a [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/), you can use  Autoscaler or Manual Scaler trait with it.
 
 ## Singleton Task
 

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -1,26 +1,26 @@
 # Quickstart Guide
 
-This guide covers how to install and configure a basic Scylla installation. For more a more detailed walk-through, see the [Installation Guide](install.md)
+This guide covers how to install and configure a basic Rudr installation. For more a more detailed walk-through, see the [Installation Guide](install.md)
 
 ## Prerequisites
 
-The following prerequisites are required for a successful use of Scylla.
+The following prerequisites are required for a successful use of Rudr.
 
 1. A copy of this repo (`git clone https://github.com/microsoft/scylla.git`)
 2. A Kubernetes cluster version 1.15 or greater
 3. `kubectl` installed and pointed at the cluster
 4. [Helm 3](https://v3.helm.sh/)
 
-To find out which cluster Scylla would install to, you can run `kubectl config current-context` or `kubectl cluster-info`.
+To find out which cluster Rudr would install to, you can run `kubectl config current-context` or `kubectl cluster-info`.
 
 ```console
 $ kubectl config current-context
 my-cluster
 ```
 
-## Install Scylla and Dependencies
+## Install Rudr and Dependencies
 
-The fastest way to install Scylla is with Helm 3.
+The fastest way to install Rudr is with Helm 3.
 
 > make sure your Helm 3 has version newer than `v3.0.0-beta.3`, or you have to install the CRDs with `kubectl apply -f charts/scylla/crds`
 
@@ -31,12 +31,12 @@ LAST DEPLOYED: 2019-10-02 13:57:33.158655 -0600 MDT m=+5.183858344
 NAMESPACE: default
 STATUS: deployed
 NOTES:
-Scylla is a Kubernetes controller to manage Configuration CRDs.
+Rudr is a Kubernetes controller to manage Configuration CRDs.
 
 It has been successfully installed.
 ```
 
-This will give you a basic installation of Scylla. For the following examples, you should also install the NGINX ingress into Kubernetes:
+This will give you a basic installation of Rudr. For the following examples, you should also install the NGINX ingress into Kubernetes:
 
 ```console
 $ helm install nginx-ingress stable/nginx-ingress
@@ -54,9 +54,9 @@ You can watch the status by running 'kubectl --namespace default get services -o
 
 This will give you a basic implementation of Kubernetes ingresses. See the [Installation Guide](install.md) for more about ingresses and other traits.
 
-## Using Scylla
+## Using Rudr
 
-Once you have installed Scylla, you can start creating and deploying apps.
+Once you have installed Rudr, you can start creating and deploying apps.
 
 To start, install an example component:
 
@@ -96,9 +96,9 @@ spec:
 
 ### Viewing Traits
 
-Scylla provides a way to attach operational features at install time. This allows application operations an opportunity to provide functionality like autoscaling, caching, or ingress control at install time, without requiring the developer to change anything in the component.
+Rudr provides a way to attach operational features at install time. This allows application operations an opportunity to provide functionality like autoscaling, caching, or ingress control at install time, without requiring the developer to change anything in the component.
 
-You can also list the traits that are available on Scylla:
+You can also list the traits that are available on Rudr:
 
 ```console
 $ kubectl get traits
@@ -181,7 +181,7 @@ $ kubectl apply -f examples/first-app-config.yaml
 configuration.core.hydra.io/first-app created
 ```
 
-You'll need to wait for a minute or two for it to fully deploy. Behind the scenes, Scylla is creating all the necessary objects.
+You'll need to wait for a minute or two for it to fully deploy. Behind the scenes, Rudr is creating all the necessary objects.
 
 Once it is fully deployed, you can see your configuration:
 
@@ -247,9 +247,9 @@ component.core.hydra.io/nginx-replicated         19h
 component.core.hydra.io/nginx-singleton          19h
 ```
 
-## Uninstall Scylla
+## Uninstall Rudr
 
-If you want to clean up your test environment and uninstall Scylla, you could do the following:
+If you want to clean up your test environment and uninstall Rudr, you could do the following:
 
  ```console
  $ helm delete scylla
@@ -267,4 +267,4 @@ If you want to clean up your test environment and uninstall Scylla, you could do
 
 ## Learn more...
 
-Read how to [use Scylla](using_scylla.md) for more details.
+Read how to [use Rudr](using_scylla.md) for more details.

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -1,8 +1,8 @@
-# Installing Scylla
+# Installing Rudr
 
 ## Prerequisites 
 
-You will need both `kubectl` and `Helm 3` to install Scylla. 
+You will need both `kubectl` and `Helm 3` to install Rudr. 
 
 1. Install `kubectl`. The below is for MacOS. For other OS, please go to https://kubernetes.io/docs/tasks/tools/install-kubectl/. 
 
@@ -48,16 +48,16 @@ $ az aks get-credentials -n scylla -g scylla
 
 At the end of this process, verify that you are connected to this cluster with `kubectl config current-context`.
 
-## Installing Scylla Using Helm 3
+## Installing Rudr Using Helm 3
 
-> Note: In its current version, Scylla will only listen for events in one namespace. This will change in the future. For now, though, you must install Scylla into the namespace into which you will deploy Scylla apps. You may install Scylla multiple times on the same cluster as long as you deploy to a different namespace each time.
+> Note: In its current version, Rudr will only listen for events in one namespace. This will change in the future. For now, though, you must install Rudr into the namespace into which you will deploy Rudr apps. You may install Rudr multiple times on the same cluster as long as you deploy to a different namespace each time.
  
-> Tip: As there are some breaking changes (such as Configuration => ApplicationConfiguration, Component => ComponentSchematic), if you reinstall Scylla, make sure your old CRDs are deleted. Helm will not automatically delete CRDs. You must do this with `kubectl delete crd`.
-> Note: In its current version, Scylla will only listen for events in one namespace. This will change in the near future.
+> Tip: As there are some breaking changes (such as Configuration => ApplicationConfiguration, Component => ComponentSchematic), if you reinstall Rudr, make sure your old CRDs are deleted. Helm will not automatically delete CRDs. You must do this with `kubectl delete crd`.
+> Note: In its current version, Rudr will only listen for events in one namespace. This will change in the near future.
  
-> Tip: As there are some breaking changes, if you reinstall Scylla, make sure your old CRDs are deleted.
+> Tip: As there are some breaking changes, if you reinstall Rudr, make sure your old CRDs are deleted.
 
-1. Helm install Scylla
+1. Helm install Rudr
 
 ```console
 $ helm install scylla ./charts/scylla --wait
@@ -67,7 +67,7 @@ NAMESPACE: default
 STATUS: deployed
 
 NOTES:
-Scylla is a Kubernetes controller to manage Configuration CRDs.
+Rudr is a Kubernetes controller to manage Configuration CRDs.
 
 It has been successfully installed.
 ```
@@ -76,7 +76,7 @@ This will install the CRDs and the controller into your Kubernetes cluster.
 
 ### Verifying the Install
 
-You can verify that Scylla is installed by fetching the CRDs:
+You can verify that Rudr is installed by fetching the CRDs:
 
 ```console
 $ kubectl get crds -l app.kubernetes.io/part-of=core.hydra.io
@@ -88,7 +88,7 @@ scopes.core.hydra.io                      2019-10-02T19:57:32Z
 traits.core.hydra.io                      2019-10-02T19:57:32Z
 ```
 
-You should see at least those five CRDs. You can also verify that the Scylla deployment is running:
+You should see at least those five CRDs. You can also verify that the Rudr deployment is running:
 
 ```console
 $ kubectl get deployment scylla
@@ -98,15 +98,15 @@ scylla   1/1     1            1           2m47s
 
 ### Upgrading
 
-To upgrade Scylla, typically you only need to use Helm.
+To upgrade Rudr, typically you only need to use Helm.
 
-> Tip: During the Alpha and Beta phase of Scylla, we recommend also deleting your CRDs manually. You must do this with `kubectl delete crd`.
+> Tip: During the Alpha and Beta phase of Rudr, we recommend also deleting your CRDs manually. You must do this with `kubectl delete crd`.
 
 ```console
 $ helm upgrade scylla charts/scylla
 ```
 
-The above will update your Scylla to the latest version.
+The above will update your Rudr to the latest version.
 
 ### Uninstalling
 
@@ -126,7 +126,7 @@ The above will delete the CRDs and clean up everything related with Open Applica
 
 ## Installing Implementations for Traits
 
-Scylla provides several traits, including ingress and autoscaler. However, it does not install default implementations of some of these. This is because they map to primitive Kubernetes features that can be fulfilled by  different controllers.
+Rudr provides several traits, including ingress and autoscaler. However, it does not install default implementations of some of these. This is because they map to primitive Kubernetes features that can be fulfilled by  different controllers.
 
 The best place to find implementations for your traits is [Helm Hub](https://hub.helm.sh/).
 
@@ -154,8 +154,8 @@ $ helm install keda stable/keda
 
 ## Running for Development
 
-Developers may prefer to run a local copy of the Scylla daemon. To do so:
+Developers may prefer to run a local copy of the Rudr daemon. To do so:
 
 1. Make sure the CRDs are installed on your target cluster
-2. Make sure your current Kubernetes context is set to your target cluster. Scylla will inherit the credentials from this context entry.
-3. From the base directory of the code, run `make run`. This will start Scylla in the foreground, running locally, but listening on the remote cluster.
+2. Make sure your current Kubernetes context is set to your target cluster. Rudr will inherit the credentials from this context entry.
+3. From the base directory of the code, run `make run`. This will start Rudr in the foreground, running locally, but listening on the remote cluster.

--- a/governance.md
+++ b/governance.md
@@ -2,10 +2,10 @@
 
 ## LGTM Policy
 
-Every code change committed to Scylla must be reviewed by at least one project maintainer who did not author the PR. When a PR has been marked `Approved` by a project maintainer and passes all mandatory gates (including the contributor license agreement verification), the PR can be merged by any project maintainer.
+Every code change committed to Rudr must be reviewed by at least one project maintainer who did not author the PR. When a PR has been marked `Approved` by a project maintainer and passes all mandatory gates (including the contributor license agreement verification), the PR can be merged by any project maintainer.
 
 ## Project Maintainers
-[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating Scylla. Final decisions on the project reside with the project maintainers.
+[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating Rudr. Final decisions on the project reside with the project maintainers.
 
 Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
 

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -118,10 +118,10 @@ fn form_metadata(
 
 type Labels = BTreeMap<String, String>;
 
-/// DeploymentBuilder builds new deployments specific to Scylla
+/// DeploymentBuilder builds new deployments specific to Rudr
 ///
 /// This hides many of the details of building a Deployment, exposing only
-/// parameters common to Scylla workload types.
+/// parameters common to Rudr workload types.
 pub(crate) struct DeploymentBuilder {
     component: Component,
     labels: Labels,
@@ -179,7 +179,11 @@ impl DeploymentBuilder {
     pub fn to_deployment(&self) -> apps::Deployment {
         apps::Deployment {
             // TODO: Could make this generic.
-            metadata: form_metadata(self.name.clone(), self.labels.clone(), self.owner_ref.clone()),
+            metadata: form_metadata(
+                self.name.clone(),
+                self.labels.clone(),
+                self.owner_ref.clone(),
+            ),
             spec: Some(apps::DeploymentSpec {
                 replicas: self.replicas,
                 selector: meta::LabelSelector {
@@ -233,10 +237,10 @@ impl DeploymentBuilder {
     }
 }
 
-/// JobBuilder builds new jobs specific to Scylla
+/// JobBuilder builds new jobs specific to Rudr
 ///
 /// This hides many of the details of building a Job, exposing only
-/// parameters common to Scylla workload types.
+/// parameters common to Rudr workload types.
 pub(crate) struct JobBuilder {
     component: Component,
     labels: Labels,
@@ -303,7 +307,11 @@ impl JobBuilder {
 
     fn to_job(&self) -> batchapi::Job {
         batchapi::Job {
-            metadata: form_metadata(self.name.clone(), self.labels.clone(), self.owner_ref.clone()),
+            metadata: form_metadata(
+                self.name.clone(),
+                self.labels.clone(),
+                self.owner_ref.clone(),
+            ),
             spec: Some(batchapi::JobSpec {
                 backoff_limit: Some(4),
                 parallelism: self.parallelism,
@@ -422,7 +430,11 @@ impl ServiceBuilder {
     fn to_service(&self) -> Option<api::Service> {
         self.component.clone().listening_port().and_then(|port| {
             Some(api::Service {
-                metadata: form_metadata(self.name.clone(), self.labels.clone(), self.owner_ref.clone()),
+                metadata: form_metadata(
+                    self.name.clone(),
+                    self.labels.clone(),
+                    self.owner_ref.clone(),
+                ),
                 spec: Some(api::ServiceSpec {
                     selector: Some(self.selector.clone()),
                     ports: Some(vec![port.to_service_port()]),


### PR DESCRIPTION
This is the first part of the Scylla -> Rudr rename. This one only changes non-functional textual occurrences of Scylla.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>