### PR TITLE
moved Rust FAQ to the faq.md document

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,6 @@ This project welcomes contributions and suggestions. See [CONTRIBUTING.md](CONTR
 
 This project follows governance structure of numerous other open source projects. See [governance.md](governance.md) for more details.
 
-## About the Name
-
-Scylla is one of the monsters in Homer's Odyssey. Odysseus must steer his ship between Scylla and Charybdis. Scylla is sometimes portrayed as a hydra.
-
-## Why Rust?
-
-On occasion, we have been asked why Scylla is written in Rust instead of Go. There is no requirement in the Kubernetes world that Kubernetes controllers be written in Go. Many languages implement the Kubernetes API and can be used for creating controllers. We decided to write Scylla in Rust because the language allows us to write Kubernetes controllers with far less code. Rust's generics make it possible to quickly and succinctly describe custom Kubernetes API resources without requiring developers to run code generators. And Rust's Kubernetes library can easily switch between Kubernetes versions with ease. We recognize that Rust might not be to everyone's taste (and neither is Go). However, we are confident that Rust is a solid choice for writing maintainable and concise Kubernetes applications.
-
 ## License
 
 This project is available under the terms of the MIT license. See [LICENSE.txt](LICENSE.txt).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,3 +42,8 @@ Currently, no. Scopes are fixed according to the Open Application Model spec.
 ## Does Scylla support "extended workload types" as described in the Open Application Model specification
 
 No. That section of the specification is a draft, and we are not yet supporting it.
+
+
+## Why Rust?
+
+On occasion, we have been asked why Scylla is written in Rust instead of Go. There is no requirement in the Kubernetes world that Kubernetes controllers be written in Go. Many languages implement the Kubernetes API and can be used for creating controllers. We decided to write Scylla in Rust because the language allows us to write Kubernetes controllers with far less code. Rust's generics make it possible to quickly and succinctly describe custom Kubernetes API resources without requiring developers to run code generators. And Rust's Kubernetes library can easily switch between Kubernetes versions with ease. We recognize that Rust might not be to everyone's taste (and neither is Go). However, we are confident that Rust is a solid choice for writing maintainable and concise Kubernetes applications.


### PR DESCRIPTION
This seems like it is better as content for the FAQ.

Also, removed Scylla etymology, since the new name has been picked.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>