### PR TITLE
WIP: implement SMI TrafficSplit as a trait

### DIFF
--- a/charts/scylla/templates/traits.yaml
+++ b/charts/scylla/templates/traits.yaml
@@ -100,7 +100,7 @@ spec:
       type: string
       required: true
     - name: weight
-      description: The weight used for routing traffic. The "heavier" the wait, the more traffic will be directed to this splitter.
+      description: The weight used for routing traffic. The "heavier" the weight, the more traffic will be directed to this splitter.
       type: int
       required: false
       default: 0

--- a/charts/scylla/templates/traits.yaml
+++ b/charts/scylla/templates/traits.yaml
@@ -96,7 +96,7 @@ spec:
     - core.hydra.io/v1alpha1.SingletonWorker
   properties:
     - name: splitterName
-      description: The name of the splitter that this should join. If no such splitter exists, it will be created.
+      description: The name of the traffic splitter that this should join. If no such splitter exists, it will be created.
       type: string
       required: true
     - name: weight

--- a/charts/scylla/templates/traits.yaml
+++ b/charts/scylla/templates/traits.yaml
@@ -87,6 +87,27 @@ spec:
 apiVersion: core.hydra.io/v1alpha1
 kind: Trait
 metadata:
+  name: traffic-split
+spec:
+  appliesTo:
+    - core.hydra.io/v1alpha1.Server
+    - core.hydra.io/v1alpha1.SingletonServer
+    - core.hydra.io/v1alpha1.Worker
+    - core.hydra.io/v1alpha1.SingletonWorker
+  properties:
+    - name: splitterName
+      description: The name of the splitter that this should join. If no such splitter exists, it will be created.
+      type: string
+      required: true
+    - name: weight
+      description: The weight used for routing traffic. The "heavier" the wait, the more traffic will be directed to this splitter.
+      type: int
+      required: false
+      default: 0
+---
+apiVersion: core.hydra.io/v1alpha1
+kind: Trait
+metadata:
   name: empty
 spec:
   appliesTo:

--- a/examples/smi-crds.yaml
+++ b/examples/smi-crds.yaml
@@ -1,0 +1,26 @@
+# Placeholder for testing SMI without installing a controller
+# Source: https://github.com/deislabs/smi-adapter-istio/blob/master/deploy/crds/crds.yaml
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: trafficsplits.split.smi-spec.io
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.service
+      description: The service
+      name: Service
+      type: string
+  group: split.smi-spec.io
+  names:
+    kind: TrafficSplit
+    listKind: TrafficSplitList
+    plural: trafficsplits
+    singular: trafficsplit
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/examples/traffic-split.yaml
+++ b/examples/traffic-split.yaml
@@ -1,0 +1,24 @@
+apiVersion: core.hydra.io/v1alpha1
+kind: ApplicationConfiguration
+metadata:
+  name: example-multi-server
+spec:
+  components:
+    - name: nginx-singleton-v1
+      instanceName: multi-singleton-1
+      traits:
+        - name: traffic-split
+          parameterValues:
+            - name: splitterName
+              value: example-traffic-splitter # <-- Note, same as below
+            - name: weight
+              value: 30
+    - name: nginx-singleton-v1
+      instanceName: multi-singleton-2
+      traits:
+        - name: traffic-split
+          parameterValues:
+            - name: splitterName
+              value: example-traffic-splitter # <-- Note, same as above
+            - name: weight
+              value: 70

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,10 @@ extern crate failure;
 extern crate serde_derive;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate log;
 extern crate regex;
 
 pub mod instigator;

--- a/src/schematic/traits.rs
+++ b/src/schematic/traits.rs
@@ -14,6 +14,8 @@ mod manual_scaler;
 pub use crate::schematic::traits::manual_scaler::ManualScaler;
 mod volume_mounter;
 pub use crate::schematic::traits::volume_mounter::VolumeMounter;
+mod traffic_split;
+pub use crate::schematic::traits::traffic_split::TrafficSplit;
 mod util;
 use crate::schematic::traits::util::*;
 use std::collections::BTreeMap;
@@ -31,6 +33,7 @@ pub const INGRESS: &str = "ingress";
 pub const AUTOSCALER: &str = "autoscaler";
 pub const MANUAL_SCALER: &str = "manual-scaler";
 pub const VOLUME_MOUNTER: &str = "volume-mounter";
+pub const TRAFFIC_SPLIT: &str = "traffic-split";
 pub const EMPTY: &str = "empty";
 
 /// Trait describes OAM traits.
@@ -62,6 +65,7 @@ pub enum OAMTrait {
     ManualScaler(ManualScaler),
     Ingress(Ingress),
     VolumeMounter(VolumeMounter),
+    TrafficSplit(TrafficSplit),
     Empty(Empty),
 }
 impl OAMTrait {
@@ -72,6 +76,7 @@ impl OAMTrait {
             OAMTrait::ManualScaler(m) => m.exec(ns, client, phase),
             OAMTrait::VolumeMounter(v) => v.exec(ns, client, phase),
             OAMTrait::Empty(e) => e.exec(ns, client, phase),
+            OAMTrait::TrafficSplit(t) => t.exec(ns, client, phase),
         }
     }
     pub fn status(&self, ns: &str, client: APIClient) -> Option<BTreeMap<String, String>> {
@@ -81,6 +86,7 @@ impl OAMTrait {
             OAMTrait::ManualScaler(m) => m.status(ns, client),
             OAMTrait::Empty(e) => e.status(ns, client),
             OAMTrait::VolumeMounter(v) => v.status(ns, client),
+            OAMTrait::TrafficSplit(t) => t.status(ns, client),
         }
     }
 }

--- a/src/schematic/traits/traffic_split.rs
+++ b/src/schematic/traits/traffic_split.rs
@@ -1,0 +1,194 @@
+use k8s_openapi::api::core::v1 as core;
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as meta;
+use kube::client::APIClient;
+use kube::api::{RawApi, Object, PostParams, PatchParams};
+
+use crate::schematic::{
+    component::{AccessMode, Component, SharingPolicy, Volume},
+    traits::util::{OwnerRefs, TraitResult},
+    traits::TraitImplementation,
+};
+use crate::workload_type::ParamMap;
+
+use std::collections::BTreeMap;
+
+
+// Kubernetes spec for TrafficSplit.
+#[derive(Deserialize, Serialize, Clone)]
+struct TrafficSplitSpec {
+    service: String,
+    backends: Vec<Backend>,
+}
+// Kubernetes structure for the backend members for a split.
+#[derive(Deserialize, Serialize, Clone)]
+struct Backend {
+    service: String,
+    weight: i64,
+}
+// Provides access to the status from the SMI implementation
+#[derive(Deserialize, Serialize, Clone, Default, Debug)]
+struct TrafficSplitStatus {}
+
+/// A TrafficSplit custom resource for Kubernetes
+type TrafficSplitCR = Object<TrafficSplitSpec, TrafficSplitStatus>;
+
+
+/// The OAM Trait for SMI traffic splitters.
+pub struct TrafficSplit {
+        /// The app configuration name
+    pub name: String,
+    /// The instance name for this component
+    pub instance_name: String,
+    /// The component name
+    pub component_name: String,
+    /// The owner reference (usually of the component instance).
+    /// This should be attached to any Kubernetes resources that this trait creates.
+    pub owner_ref: OwnerRefs,
+    /// The component that we are attaching to
+    //pub component: Component,
+    /// The name of the traffic splitter that this should join.
+    pub splitter_name: String,
+    /// The split weight. Defaults to 0
+    pub weight: i64
+}
+
+impl TrafficSplit {
+    pub fn from_params(
+        name: String,
+        instance_name: String,
+        component_name: String,
+        params: ParamMap,
+        owner_ref: OwnerRefs,
+        //component: Component,
+    ) -> Self {
+        TrafficSplit {
+            name,
+            component_name,
+            instance_name,
+            owner_ref,
+            //component,
+            splitter_name: params
+                .get("splitterName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            weight: params
+                .get("weight")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0),
+        }
+    }
+    fn labels(&self) -> BTreeMap<String, String> {
+        let mut labels = BTreeMap::new();
+        labels.insert("app".to_string(), self.name.clone());
+        labels.insert("component-name".to_string(), self.component_name.clone());
+        labels.insert("instance-name".to_string(), self.instance_name.clone());
+        labels.insert("trait".to_string(), "traffic-split".to_string());
+        labels
+    }
+
+    /// Create or update a splitter.
+    /// 
+    /// For both add and modify, it is possible to have a situation where the
+    /// splitter exists and needs to be created, as well as a situation where the
+    /// splitter does not exist.
+    fn create_or_update_splitter(&self, ns: &str, client: APIClient) -> TraitResult {
+        let splitter = RawApi::customResource("trafficsplits").version("v1alpha1").group("split.smi-spec.io").within(ns);
+        // First, see if splitter already exists
+        match client.request::<TrafficSplitCR>(splitter.get(self.splitter_name.as_str())?) {
+            Ok(current) => {
+                // If found, patch it.
+                let modified_def = json!({
+                    "spec": {
+                        "backends": [
+                            {
+                                "service": self.instance_name.as_str(),
+                                "weight": self.weight,
+                            }
+                        ]
+                    }
+                });
+                let pp = PatchParams::default();
+                let patch = serde_json::to_vec(&modified_def)?;
+                let req = splitter.patch(self.splitter_name.as_str(), &pp, patch)?;
+                let res = client.request::<TrafficSplitCR>(req)?;
+                info!("Patched TrafficSplitter");
+                //debug!("TrafficSplitter: {:?}", res);
+            },
+            // We want to catch the case where an error comes back saying the resource does not exist.
+            Err(ref e) if e.api_error().map_or(false, |err| err.code == 404 ) => {
+                info!("Error code: {}", e.api_error().unwrap().code);
+                // If not found, create it
+                log::info!("found no splitter to modify");
+                let splitter_def = json!({
+                    "apiVersion": "split.smi-spec.io/v1alpha1",
+                    "kind": "TrafficSplit",
+                    "metadata": {
+                        "labels": self.labels(),
+                    },
+                    "spec": {
+                        "service": self.splitter_name.as_str(),
+                        "backends": [
+                            {
+                                "service": self.instance_name.as_str(),
+                                "weight": self.weight,
+                            }
+                        ]
+                    }
+                    
+                });
+
+                let pp = PostParams::default();
+                let req = splitter.create(&pp, serde_json::to_vec(&splitter_def)?)?;
+                let res = client.request::<TrafficSplitCR>(req)?;
+                info!("Created new TrafficSplit {} for {}", self.splitter_name.clone(), self.instance_name.clone());
+                //debug!("TrafficSplitter: {:?}", res);
+            }
+            // All other errors result in failure to create an SMI site
+            Err(e) => {
+                error!("Unexpected response from API server: {}", e);
+                return Err(e.into())
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TraitImplementation for TrafficSplit {
+ fn add(&self, ns: &str, client: APIClient) -> TraitResult {
+        self.create_or_update_splitter(ns, client)
+    }
+    fn modify(&self, ns: &str, client: APIClient) -> TraitResult {
+        self.create_or_update_splitter(ns, client)
+    }
+    fn delete(&self, ns: &str, client: APIClient) -> TraitResult {
+        Ok(())
+    }
+    fn status(&self, ns: &str, client: APIClient) -> Option<BTreeMap<String, String>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::TrafficSplit;
+    use crate::workload_type::ParamMap;
+    #[test]
+    fn test_from_params() {
+        let mut params = ParamMap::new();
+        params.insert("splitterName".into(), serde_json::json!("my-splitter"));
+        params.insert("weight".into(), serde_json::json!(10));
+        params.insert("luftBalloons".into(), serde_json::json!(99));
+        let vm = TrafficSplit::from_params(
+            "name".to_string(),
+            "instance name".to_string(),
+            "component name".to_string(),
+            params,
+            None,
+        );
+
+        assert_eq!("my-splitter", vm.splitter_name);
+        assert_eq!(10, vm.weight);
+    }
+}

--- a/src/trait_manager.rs
+++ b/src/trait_manager.rs
@@ -11,7 +11,7 @@ use crate::{
         configuration::ComponentConfiguration,
         parameter::{resolve_values, ParameterValue},
         traits::{
-            self, Autoscaler, Empty, OAMTrait, Ingress, ManualScaler, TraitBinding, VolumeMounter,
+            self, Autoscaler, Empty, OAMTrait, Ingress, ManualScaler, TraitBinding, VolumeMounter, TrafficSplit,
         },
     },
 };
@@ -92,6 +92,17 @@ impl TraitManager {
                     self.workload_type.clone(),
                 );
                 Ok(OAMTrait::ManualScaler(scaler))
+            }
+            traits::TRAFFIC_SPLIT => {
+                let splitter = TrafficSplit::from_params(
+                    self.config_name.clone(),
+                    self.instance_name.clone(),
+                    self.component.name.clone(),
+                    trait_values,
+                    self.owner_ref.clone(),
+                    //self.workload_type.clone(),
+                );
+                Ok(OAMTrait::TrafficSplit(splitter))
             }
             // Empty is a debugging tool for checking whether the traits system is functioning independently of
             // its environment.


### PR DESCRIPTION
This trait implements the SMI TrafficSplit in an interesting way: Multiple apps _join_ a traffic splitter. We lazily create splitters when needed.

Still remaining:

- [ ] Implement 'status'
- [ ] Write documentation

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>