### PR TITLE
rename hydra.io to oam.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ To get started, define some _components_. Components are not instantiated. They 
 
 ```console
 $ kubectl apply -f examples/components.yaml
-component.core.hydra.io "nginx-replicated" created
-component.core.hydra.io "nginx-singleton" created
+component.core.oam.dev "nginx-replicated" created
+component.core.oam.dev "nginx-singleton" created
 $ kubectl get components
 NAME               AGE
 nginx-replicated   17s

--- a/charts/scylla/crds/appconfigs.yaml
+++ b/charts/scylla/crds/appconfigs.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: applicationconfigurations.core.hydra.io
+  name: applicationconfigurations.core.oam.dev
   labels:
-    app.kubernetes.io/part-of: core.hydra.io
+    app.kubernetes.io/part-of: core.oam.dev
 spec:
-  group: core.hydra.io
+  group: core.oam.dev
   versions:
     - name: v1alpha1
       served: true

--- a/charts/scylla/crds/componentinstances.yaml
+++ b/charts/scylla/crds/componentinstances.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: componentinstances.core.hydra.io
+  name: componentinstances.core.oam.dev
   labels:
-    app.kubernetes.io/part-of: core.hydra.io
+    app.kubernetes.io/part-of: core.oam.dev
 spec:
-  group: core.hydra.io
+  group: core.oam.dev
   versions:
     - name: v1alpha1
       served: true

--- a/charts/scylla/crds/componentschematics.yaml
+++ b/charts/scylla/crds/componentschematics.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: componentschematics.core.hydra.io
+  name: componentschematics.core.oam.dev
   labels:
-    app.kubernetes.io/part-of: core.hydra.io
+    app.kubernetes.io/part-of: core.oam.dev
 spec:
-  group: core.hydra.io
+  group: core.oam.dev
   versions:
     - name: v1alpha1
       served: true

--- a/charts/scylla/crds/scopes.yaml
+++ b/charts/scylla/crds/scopes.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: scopes.core.hydra.io
+  name: scopes.core.oam.dev
   labels:
-    app.kubernetes.io/part-of: core.hydra.io
+    app.kubernetes.io/part-of: core.oam.dev
 spec:
-  group: core.hydra.io
+  group: core.oam.dev
   versions:
     - name: v1alpha1
       served: true

--- a/charts/scylla/crds/traits.yaml
+++ b/charts/scylla/crds/traits.yaml
@@ -1,11 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: traits.core.hydra.io
+  name: traits.core.oam.dev
   labels:
-    app.kubernetes.io/part-of: core.hydra.io
+    app.kubernetes.io/part-of: core.oam.dev
 spec:
-  group: core.hydra.io
+  group: core.oam.dev
   versions:
     - name: v1alpha1
       served: true

--- a/charts/scylla/templates/rolebinding.yaml
+++ b/charts/scylla/templates/rolebinding.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
 {{ include "scylla.labels" . | indent 4 }}
 rules:
-- apiGroups: ["", "apps", "batch", "extensions", "core.hydra.io", "apiextensions.k8s.io"]
+- apiGroups: ["", "apps", "batch", "extensions", "core.oam.dev", "apiextensions.k8s.io"]
   resources: ["*"]
   verbs: ["*"]
 

--- a/charts/scylla/templates/traits.yaml
+++ b/charts/scylla/templates/traits.yaml
@@ -1,11 +1,11 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   name: autoscaler
 spec:
   appliesTo:
-    - core.hydra.io/v1alpha1.Server
-    - core.hydra.io/v1alpha1.Task
+    - core.oam.dev/v1alpha1.Server
+    - core.oam.dev/v1alpha1.Task
   properties:
     - name: minimum
       description: Minumum number of replicas to start. Default 1
@@ -24,14 +24,14 @@ spec:
       type: int
       required: false
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   name: manual-scaler
 spec:
   appliesTo:
-    - core.hydra.io/v1alpha1.Server
-    - core.hydra.io/v1alpha1.Task
+    - core.oam.dev/v1alpha1.Server
+    - core.oam.dev/v1alpha1.Task
   properties:
     - name: replicaCount
       description: Number of replicas to start
@@ -39,14 +39,14 @@ spec:
       required: true
 
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   name: ingress
 spec:
   appliesTo:
-    - core.hydra.io/v1alpha1.Server
-    - core.hydra.io/v1alpha1.SingletonServer
+    - core.oam.dev/v1alpha1.Server
+    - core.oam.dev/v1alpha1.SingletonServer
   properties:
     - name: hostname
       description: Host name for the ingress
@@ -62,18 +62,18 @@ spec:
       required: false
 
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   name: volume-mounter
 spec:
   appliesTo:
-    - core.hydra.io/v1alpha1.Server
-    - core.hydra.io/v1alpha1.SingletonServer
-    - core.hydra.io/v1alpha1.Worker
-    - core.hydra.io/v1alpha1.SingletonWorker
-    - core.hydra.io/v1alpha1.Task
-    - core.hydra.io/v1alpha1.SingletonTask
+    - core.oam.dev/v1alpha1.Server
+    - core.oam.dev/v1alpha1.SingletonServer
+    - core.oam.dev/v1alpha1.Worker
+    - core.oam.dev/v1alpha1.SingletonWorker
+    - core.oam.dev/v1alpha1.Task
+    - core.oam.dev/v1alpha1.SingletonTask
   properties:
     - name: volumeName
       description: The name of the volume this backs. This matches the volume name declared in the ComponentSchematic.
@@ -84,7 +84,7 @@ spec:
       type: string
       required: true
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   name: empty

--- a/docs/concepts/application-configuration.md
+++ b/docs/concepts/application-configuration.md
@@ -14,7 +14,7 @@ The key parts of an application configuration include:
 Here's an example application configuration (*.yaml* file):
 
 <pre>
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 <b style="color:blue;">metadata</b>:
   name: first-app

--- a/docs/concepts/component-schematic.md
+++ b/docs/concepts/component-schematic.md
@@ -14,12 +14,12 @@ The key parts of a component schematic include:
 Here's an example application configuration (*.yaml* file):
 
 <pre>
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 <b style="color:blue;">metadata:</b>
   name: alpine-forever-v1
 spec:
-  <b style="color:blue;">workloadType:</b> core.hydra.io/v1alpha1.SingletonServer
+  <b style="color:blue;">workloadType:</b> core.oam.dev/v1alpha1.SingletonServer
   <b style="color:blue;">parameters:</b>
     - name: message
            type: string
@@ -104,7 +104,7 @@ A component must declare its associated [workload type](https://github.com/micro
 [Here's an example](../../examples/helloworld-python-component.yaml) declaration of the component workload type:
 
 ```yaml
-workloadType: core.hydra.io/v1alpha1.Server
+workloadType: core.oam.dev/v1alpha1.Server
 ```
 
 ## Parameters

--- a/docs/concepts/traits.md
+++ b/docs/concepts/traits.md
@@ -11,7 +11,7 @@ Currently, Scylla supports the following traits:
 An [application operator](https://github.com/microsoft/hydra-spec/blob/master/2.overview_and_terminology.md#roles-and-responsibilities) assigns specific traits to component workloads of an application from the [ApplicationConfiguration](application-configuration.md) manifest. For example:
 
 <pre>
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app
@@ -136,7 +136,7 @@ To find your service port, you can do one of two things:
 For example, here's how to find the port on a `ComponentSchematic`:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: nginx-replicated-v1
@@ -148,13 +148,13 @@ spec:
     - containerPort: 80                  # <-- this is the service port
       name: http
       protocol: TCP
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
 ```
 
 So to use this on an ingress, you would need to add this to your `ApplicationConfiguration`:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example
@@ -182,12 +182,12 @@ The Volume Mounter trait is responsible for attaching Kubernetes Persistent Volu
 When creating components, component authors may indicate that a container needs a storage to be attached as a volume.
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: server-with-volume-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: nginx:latest
@@ -205,12 +205,12 @@ In the `resources` section above, one volume is required. It must be at least `5
 Sometimes, components need to persist data. In such cases, the `ephemeral` flag should be set to `false`:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: server-with-volume-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: nginx:latest
@@ -226,7 +226,7 @@ spec:
 In the Kubernetes implementation of OAM, a Persistent Volume Claim (PVC) is used to satisfy the non-ephemeral case. However, by default Scylla does not create this PVC automatically. A trait must be applied that will indicate how the PVC is created:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-server-with-volume

--- a/docs/developer/writing_a_trait.md
+++ b/docs/developer/writing_a_trait.md
@@ -10,7 +10,7 @@ The first thing we will do is define a trait resource as a YAML file that Helm w
 
 ```yaml
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   # Define the name of the trait. This will be the reference by which ApplicationConfigurations
@@ -20,12 +20,12 @@ spec:
   # The appliesTo field lists all of the Workload Types that this trait can be added to.
   # In this case, all of the core workload types are supported.
   appliesTo:
-    - core.hydra.io/v1alpha1.Server
-    - core.hydra.io/v1alpha1.SingletonServer
-    - core.hydra.io/v1alpha1.Worker
-    - core.hydra.io/v1alpha1.SingletonWorker
-    - core.hydra.io/v1alpha1.Task
-    - core.hydra.io/v1alpha1.SingletonTask
+    - core.oam.dev/v1alpha1.Server
+    - core.oam.dev/v1alpha1.SingletonServer
+    - core.oam.dev/v1alpha1.Worker
+    - core.oam.dev/v1alpha1.SingletonWorker
+    - core.oam.dev/v1alpha1.Task
+    - core.oam.dev/v1alpha1.SingletonTask
   # Properties define what things can be configured on this trait.
   #
   # A property definition requires four fields:

--- a/docs/how-to/create_component_from_scratch.md
+++ b/docs/how-to/create_component_from_scratch.md
@@ -33,20 +33,20 @@ The following instructions will lead you to build a image from source, you can g
 
 Now we have a docker image named `hydraoss/helloworld-python:v1`, so we can use this image to create a component schematics file.
 
-1. Choose the workloadType: the `helloworld-python` is very typical web application, it is stateless, always running as a service, can be replicated. So we use `core.hydra.io/v1alpha1.Server` without doubt.
+1. Choose the workloadType: the `helloworld-python` is very typical web application, it is stateless, always running as a service, can be replicated. So we use `core.oam.dev/v1alpha1.Server` without doubt.
 2. Fill the container spec and make ENV configurable: obviously we have two major environment variables in the image, one is TARGET and the other is PORT.
 3. Make parameters so we could let Application Configuration configure these environments.
 
 After these three concerns, we could figure out this basic component schematic yaml like below: 
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: helloworld-python-v1
 spec:
   name: helloworld-python
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: foo
       image: hydraoss/helloworld-python:v1
@@ -74,7 +74,7 @@ Finally we could apply this yaml to the platform and let our operators to deploy
 
 ```shell script
 $ kubectl apply -f examples/helloworld-python-component.yaml
-componentschematic.core.hydra.io/helloworld-python-v1 created
+componentschematic.core.oam.dev/helloworld-python-v1 created
 ```
 
 You can check if your component schematic is OK with:
@@ -125,14 +125,14 @@ docker push hydraoss/helloworld-python:v2
 Change the component with a new name.
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
 - name: helloworld-python-v1
 - name: helloworld-python-v2
 spec:
   name: helloworld-python
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: foo
 -     image: hydraoss/helloworld-python:v1
@@ -160,7 +160,7 @@ Apply the changed component:
 
 ```console
 $ kubectl apply -f examples/helloworld-python-component.yaml
-componentschematic.core.hydra.io/helloworld-python-v2 created
+componentschematic.core.oam.dev/helloworld-python-v2 created
 ```
 
 ### Check the result

--- a/docs/how-to/using_scylla.md
+++ b/docs/how-to/using_scylla.md
@@ -15,12 +15,12 @@ The component schematics is where developers declare the operational characteris
 In Scylla, the schema of component schematics is something like below:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: nginx-replicated
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   osType: linux
   arch: amd64
   containers:
@@ -104,7 +104,7 @@ So this is the **action** that will make the real application run in Kubernetes.
 The configuration schema is like below:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app

--- a/docs/how-to/workloads.md
+++ b/docs/how-to/workloads.md
@@ -4,12 +4,12 @@ Now Scylla has all the core workload type, they are as belows:
 
 |Name|Type|Service endpoint|Replicable|Daemonized|
 |-|-|-|-|-|
-|Server|core.hydra.io/v1alpha1.Server|Yes|Yes|Yes
-|Singleton Server|core.hydra.io/v1alpha1.SingletonServer|Yes|No|Yes
-|Task|core.hydra.io/v1alpha1.Task|No|Yes|No
-|Singleton Task|core.hydra.io/v1alpha1.SingletonTask|No|No|No
-|Worker|core.hydra.io/v1alpha1.Worker|No|Yes|Yes
-|Singleton Worker|core.hydra.io/v1alpha1.SingletonWorker|No|No|Yes
+|Server|core.oam.dev/v1alpha1.Server|Yes|Yes|Yes
+|Singleton Server|core.oam.dev/v1alpha1.SingletonServer|Yes|No|Yes
+|Task|core.oam.dev/v1alpha1.Task|No|Yes|No
+|Singleton Task|core.oam.dev/v1alpha1.SingletonTask|No|No|No
+|Worker|core.oam.dev/v1alpha1.Worker|No|Yes|Yes
+|Singleton Worker|core.oam.dev/v1alpha1.SingletonWorker|No|No|Yes
 
 ## Server
 

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -78,7 +78,7 @@ You can look at an individual component:
 
 ```console
 $ kubectl get componentschematic helloworld-python-v1 -o yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   creationTimestamp: "2019-10-08T13:02:23Z"
@@ -115,7 +115,7 @@ And you can look at an individual trait in the same way that you investigate a c
 
 ```console
 $ kubectl get trait ingress -o yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: Trait
 metadata:
   creationTimestamp: "2019-10-02T19:57:37Z"
@@ -123,12 +123,12 @@ metadata:
   name: ingress
   namespace: default
   resourceVersion: "117813"
-  selfLink: /apis/core.hydra.io/v1alpha1/namespaces/default/traits/ingress
+  selfLink: /apis/core.oam.dev/v1alpha1/namespaces/default/traits/ingress
   uid: 9f82c346-c8c6-4780-9949-3ecfd47879f9
 spec:
   appliesTo:
-  - core.hydra.io/v1alpha1.Server
-  - core.hydra.io/v1alpha1.SingletonServer
+  - core.oam.dev/v1alpha1.Server
+  - core.oam.dev/v1alpha1.SingletonServer
   properties:
   - description: Host name for the ingress
     name: hostname
@@ -151,7 +151,7 @@ The above describes a trait that attaches an ingress to a component, handling th
 When you are ready to try installing something, take a look at the `examples/first-app-config.yaml`, which shows a basic Application Configuration with a single trait applied:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app
@@ -181,7 +181,7 @@ To install this application configuration, use `kubectl`:
 
 ```console
 $ kubectl apply -f examples/first-app-config.yaml
-configuration.core.hydra.io/first-app created
+configuration.core.oam.dev/first-app created
 ```
 
 You'll need to wait for a minute or two for it to fully deploy. Behind the scenes, Scylla is creating all the necessary objects.
@@ -193,7 +193,7 @@ $ kubectl get configurations
 NAME        AGE
 first-app   4m23s
 $ kubectl get configuration first-app -o yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   annotations:
@@ -203,7 +203,7 @@ metadata:
   name: first-app
   namespace: default
   resourceVersion: "2020150"
-  selfLink: /apis/core.hydra.io/v1alpha1/namespaces/default/applicationconfigurations/first-app
+  selfLink: /apis/core.oam.dev/v1alpha1/namespaces/default/applicationconfigurations/first-app
   uid: 2ea9f384-993c-42b0-803a-43a1c273d291
 spec:
   components:
@@ -266,7 +266,7 @@ But someday, the operator may want to change something. For example:
 So you could change `first-app-config.yaml` like below:
 
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app
@@ -298,7 +298,7 @@ Again we apply this yaml:
 
 ```console
 $ kubectl apply -f examples/first-app-config.yaml
-applicationconfiguration.core.hydra.io/first-app configured
+applicationconfiguration.core.oam.dev/first-app configured
 ```
 
 ### Check the updated app
@@ -307,7 +307,7 @@ Then check the applied yaml first:
 
 ```console
 $ kubectl get configuration first-app -o yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   annotations:
@@ -317,7 +317,7 @@ metadata:
   name: first-app
   namespace: default
   resourceVersion: "2022598"
-  selfLink: /apis/core.hydra.io/v1alpha1/namespaces/default/applicationconfigurations/first-app
+  selfLink: /apis/core.oam.dev/v1alpha1/namespaces/default/applicationconfigurations/first-app
   uid: 2ea9f384-993c-42b0-803a-43a1c273d291
 spec:
   components:
@@ -375,7 +375,7 @@ You can find more details about how we create it in [Upgrade Component](../how-t
 We need to change and apply the configuration file to make the component upgrade work.
  
 ```yaml
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app
@@ -405,7 +405,7 @@ Apply it:
  
 ```shell script
 $ kubectl apply -f examples/first-app-config.yaml
-applicationconfiguration.core.hydra.io/first-app configured
+applicationconfiguration.core.oam.dev/first-app configured
 ```
 
 ### Check the upgrade result
@@ -430,7 +430,7 @@ You can delete your configurations easily with `kubectl`:
 
 ```console
 $ kubectl delete configuration first-app
-configuration.core.hydra.io "first-app" deleted
+configuration.core.oam.dev "first-app" deleted
 ```
 
 That will delete your application and all associated resources.
@@ -440,17 +440,17 @@ It will _not_ delete the traits and the components, they are happily waiting you
 ```console
 $ kubectl get traits,components
 NAME                                AGE
-trait.core.hydra.io/autoscaler      31m
-trait.core.hydra.io/empty           31m
-trait.core.hydra.io/ingress         31m
-trait.core.hydra.io/manual-scaler   31m
+trait.core.oam.dev/autoscaler      31m
+trait.core.oam.dev/empty           31m
+trait.core.oam.dev/ingress         31m
+trait.core.oam.dev/manual-scaler   31m
 
 NAME                                             AGE
-component.core.hydra.io/alpine-replicable-task   19h
-component.core.hydra.io/alpine-task              19h
-component.core.hydra.io/hpa-example-replicated   19h
-component.core.hydra.io/nginx-replicated         19h
-component.core.hydra.io/nginx-singleton          19h
+component.core.oam.dev/alpine-replicable-task   19h
+component.core.oam.dev/alpine-task              19h
+component.core.oam.dev/hpa-example-replicated   19h
+component.core.oam.dev/nginx-replicated         19h
+component.core.oam.dev/nginx-singleton          19h
 ```
 
 ## Uninstall Scylla
@@ -466,7 +466,7 @@ If you want to clean up your test environment and uninstall Scylla, you could do
  **NOTE: When you delete the CRDs, it will delete everything touching Open Application Model from configurations to secrets.**
  
  ```console
- kubectl delete crd -l app.kubernetes.io/part-of=core.hydra.io
+ kubectl delete crd -l app.kubernetes.io/part-of=core.oam.dev
  ```
  
  The above will delete the CRDs and clean up everything related with Open Application Model.

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -52,13 +52,13 @@ This will install the CRDs and the controller into your Kubernetes cluster.
 You can verify that Scylla is installed by fetching the CRDs:
 
 ```console
-$ kubectl get crds -l app.kubernetes.io/part-of=core.hydra.io
+$ kubectl get crds -l app.kubernetes.io/part-of=core.oam.dev
 NAME                                      CREATED AT
-applicationconfigurations.core.hydra.io   2019-10-02T19:57:32Z
-componentinstances.core.hydra.io          2019-10-02T19:57:32Z
-componentschematics.core.hydra.io         2019-10-02T19:57:32Z
-scopes.core.hydra.io                      2019-10-02T19:57:32Z
-traits.core.hydra.io                      2019-10-02T19:57:32Z
+applicationconfigurations.core.oam.dev   2019-10-02T19:57:32Z
+componentinstances.core.oam.dev          2019-10-02T19:57:32Z
+componentschematics.core.oam.dev         2019-10-02T19:57:32Z
+scopes.core.oam.dev                      2019-10-02T19:57:32Z
+traits.core.oam.dev                      2019-10-02T19:57:32Z
 ```
 
 You should see at least those five CRDs. You can also verify that the Scylla deployment is running:
@@ -92,7 +92,7 @@ This will leave the CRDs and configurations intact.
 **NOTE: When you delete the CRDs, it will delete everything touching Open Application Model from configurations to secrets.**
 
 ```console
-kubectl delete crd -l app.kubernetes.io/part-of=core.hydra.io
+kubectl delete crd -l app.kubernetes.io/part-of=core.oam.dev
 ```
 
 The above will delete the CRDs and clean up everything related with Open Application Model.

--- a/examples/autoscaler.yaml
+++ b/examples/autoscaler.yaml
@@ -1,6 +1,6 @@
 # This will create a Horizontal Pod Autoscaler, but your cluster must have
 # an implementation of an HPA before this will actually cause autoscaling.
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: autoscaler-example

--- a/examples/components.yaml
+++ b/examples/components.yaml
@@ -1,9 +1,9 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: hpa-example-replicated-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: k8s.gcr.io/hpa-example:latest
@@ -17,12 +17,12 @@ spec:
         memory:
           required: 100M
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: nginx-replicated-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: nginx:latest
@@ -31,12 +31,12 @@ spec:
           containerPort: 80
           protocol: TCP
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: nginx-singleton-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonServer
+  workloadType: core.oam.dev/v1alpha1.SingletonServer
   containers:
     - name: server
       image: nginx:latest
@@ -45,45 +45,45 @@ spec:
           containerPort: 80
           protocol: TCP
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: alpine-task-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Task
+  workloadType: core.oam.dev/v1alpha1.Task
   osType: linux
   containers:
     - name: runner
       image: alpine:latest
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: alpine-singleton-task-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonTask
+  workloadType: core.oam.dev/v1alpha1.SingletonTask
   osType: linux
   containers:
     - name: runner
       image: alpine:latest
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: alpine-singleton-worker-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonWorker
+  workloadType: core.oam.dev/v1alpha1.SingletonWorker
   osType: linux
   containers:
     - name: worker
       image: nginx:latest
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: alpine-worker-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Worker
+  workloadType: core.oam.dev/v1alpha1.Worker
   osType: linux
   containers:
     - name: worker

--- a/examples/env-vars.yaml
+++ b/examples/env-vars.yaml
@@ -10,12 +10,12 @@
 ##
 ## You can get that pod's logs to see the results of injecting the FOO
 ## variable.
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: alpine-forever-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonServer
+  workloadType: core.oam.dev/v1alpha1.SingletonServer
   parameters:
     - name: message
       type: string
@@ -35,7 +35,7 @@ spec:
           value: "1234"
           fromParam: unused_integer
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-env-vars

--- a/examples/first-app-config.yaml
+++ b/examples/first-app-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: first-app

--- a/examples/helloworld-python-component.yaml
+++ b/examples/helloworld-python-component.yaml
@@ -1,10 +1,10 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: helloworld-python-v1
 spec:
   name: helloworld-python
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: foo
       image: hydraoss/helloworld-python:v1

--- a/examples/image-pull-secret.yaml
+++ b/examples/image-pull-secret.yaml
@@ -4,19 +4,19 @@
 # kubectl create secret docker-registry example-image-pull-secret --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>
 #
 
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: image-pull-secret-example-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Task
+  workloadType: core.oam.dev/v1alpha1.Task
   osType: linux
   containers:
     - name: runner
       image: alpine:latest
       imagePullSecret: example-image-pull-secret
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-image-pull-secret-task

--- a/examples/manual-scaler.yaml
+++ b/examples/manual-scaler.yaml
@@ -1,6 +1,6 @@
 # Manual scaling is enabled by trait.
 # This example shows how to apply a manual scaler to a replicatable service.
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: manual-scaler-example

--- a/examples/multi-component.yaml
+++ b/examples/multi-component.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-multi-component

--- a/examples/multi-server.yaml
+++ b/examples/multi-server.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-multi-server

--- a/examples/nginx-component.yaml
+++ b/examples/nginx-component.yaml
@@ -1,10 +1,10 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: nginx-component-v1
 spec:
   name: nginx-component
-  workloadType: core.hydra.io/v1alpha1.SingletonServer
+  workloadType: core.oam.dev/v1alpha1.SingletonServer
   osType: linux
   arch: amd64
   containers:

--- a/examples/replicable-task.yaml
+++ b/examples/replicable-task.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-replicable-task

--- a/examples/task.yaml
+++ b/examples/task.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-task

--- a/examples/volumes.yaml
+++ b/examples/volumes.yaml
@@ -1,10 +1,10 @@
 # This is a stand-alone example of using a volume with a component.
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: server-with-volume-v1
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: nginx:latest
@@ -16,7 +16,7 @@ spec:
               required: "50M"
               ephemeral: false
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: example-server-with-volume

--- a/examples/voting/components.yaml
+++ b/examples/voting/components.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: voting-admin-v1
@@ -6,7 +6,7 @@ metadata:
     version: "1.0.0"
     description: Voting results interface
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       ports:
@@ -14,7 +14,7 @@ spec:
           name: http
       image: dockersamples/examplevotingapp_result:before
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: postgres-v9
@@ -22,7 +22,7 @@ metadata:
     version: "1.0.0"
     description: PostgreSQL Database
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonServer
+  workloadType: core.oam.dev/v1alpha1.SingletonServer
   containers:
     - name: db
       ports:
@@ -30,7 +30,7 @@ spec:
           name: pgsql
       image: postgres:9.4
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: redis-v1
@@ -38,7 +38,7 @@ metadata:
     version: "1.0.0"
     description: Redis single-node
 spec:
-  workloadType: core.hydra.io/v1alpha1.SingletonServer
+  workloadType: core.oam.dev/v1alpha1.SingletonServer
   containers:
     - name: cache
       ports:
@@ -46,7 +46,7 @@ spec:
           name: redis
       image: redis:alpine
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: voting-frontend-v1
@@ -54,7 +54,7 @@ metadata:
     version: "1.0.0"
     description: Voting front-end webserver
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       ports:
@@ -62,7 +62,7 @@ spec:
           name: http
       image: dockersamples/examplevotingapp_vote:before
 ---
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ComponentSchematic
 metadata:
   name: voting-worker-v1
@@ -70,7 +70,7 @@ metadata:
     version: "1.0.0"
     description: Worker for tallying voting results
 spec:
-  workloadType: core.hydra.io/v1alpha1.Server
+  workloadType: core.oam.dev/v1alpha1.Server
   containers:
     - name: server
       image: dockersamples/examplevotingapp_worker

--- a/examples/voting/configuration.yaml
+++ b/examples/voting/configuration.yaml
@@ -1,6 +1,6 @@
 # This is a single-shot configuration that creates the entire Docker Voting app
 # all in one go.
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: voter-app

--- a/examples/worker.yaml
+++ b/examples/worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.hydra.io/v1alpha1
+apiVersion: core.oam.dev/v1alpha1
 kind: ApplicationConfiguration
 metadata:
   name: worker-app

--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 
-pub const CONFIG_GROUP: &str = "core.hydra.io";
+pub const CONFIG_GROUP: &str = "core.oam.dev";
 pub const CONFIG_VERSION: &str = "v1alpha1";
 
 pub const CONFIG_CRD: &str = "applicationconfigurations";
@@ -637,7 +637,7 @@ pub fn get_component_def(
 ) -> Result<KubeComponent, Error> {
     let component_resource = RawApi::customResource(COMPONENT_CRD)
         .version("v1alpha1")
-        .group("core.hydra.io")
+        .group("core.oam.dev")
         .within(&namespace);
     let comp_def_req = component_resource.get(comp_name.as_str())?;
     let comp_def: KubeComponent = client.request::<KubeComponent>(comp_def_req)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ fn precheck_crds(client: &APIClient) -> Result<(), failure::Error> {
     let crds = vec![CONFIG_CRD, TRAIT_CRD, COMPONENT_CRD, SCOPE_CRD];
     for crd in crds.iter() {
         let req = RawApi::v1beta1CustomResourceDefinition()
-            .get(format!("{}.core.hydra.io", crd).as_str())?;
+            .get(format!("{}.core.oam.dev", crd).as_str())?;
         if let Err(e) = client.request::<CrdObj>(req) {
             error!("Error prechecking CRDs: {}", e);
             return Err(failure::format_err!("Missing CRD {}", crd));

--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use crate::schematic::parameter::{resolve_value, ParameterList, ParameterType, ResolvedVals};
 
 /// The default workload type if none is present.
-pub const DEFAULT_WORKLOAD_TYPE: &str = "core.hydra.io/v1alpha1.Singleton";
+pub const DEFAULT_WORKLOAD_TYPE: &str = "core.oam.dev/v1alpha1.Singleton";
 
 /// Component describes the "spec" of an OAM component schematic.
 ///

--- a/src/schematic/component_test.rs
+++ b/src/schematic/component_test.rs
@@ -6,10 +6,10 @@ use std::str::FromStr;
 
 #[test]
 fn test_group_version_kind() {
-    let gvk = GroupVersionKind::from_str("core.hydra.io/v1alpha1.Singleton");
+    let gvk = GroupVersionKind::from_str("core.oam.dev/v1alpha1.Singleton");
     assert!(gvk.is_ok());
     let o = gvk.unwrap();
-    assert_eq!("core.hydra.io", o.group);
+    assert_eq!("core.oam.dev", o.group);
     assert_eq!("v1alpha1", o.version);
     assert_eq!("Singleton", o.kind);
 
@@ -21,7 +21,7 @@ fn test_group_version_kind() {
 fn test_component_deserialize() {
     let data = Component::from_str(
         r#"{
-            "workloadType": "core.hydra.io/v1.Singleton",
+            "workloadType": "core.oam.dev/v1.Singleton",
             "osType": "linux",
             "arch": "amd64",
             "parameters": [],
@@ -34,7 +34,7 @@ fn test_component_deserialize() {
     let component = data.unwrap();
     assert_eq!(Some("linux".to_string()), component.os_type);
     assert_eq!(Some("amd64".to_string()), component.arch);
-    assert_eq!("core.hydra.io/v1.Singleton", component.workload_type);
+    assert_eq!("core.oam.dev/v1.Singleton", component.workload_type);
 
     let gvk = GroupVersionKind::from_str(component.workload_type.as_str());
     assert!(gvk.is_ok());

--- a/src/schematic/traits/util.rs
+++ b/src/schematic/traits/util.rs
@@ -12,7 +12,7 @@ type Labels = BTreeMap<String, String>;
 /// Generate the common labels for a trait.
 pub fn trait_labels(name: String, inst_name: String) -> Labels {
     let mut labels: Labels = BTreeMap::new();
-    labels.insert("hydra.io/role".into(), "trait".into());
+    labels.insert("oam.dev/role".into(), "trait".into());
     labels.insert("app.kubernetes.io/name".to_string(), name);
     labels.insert("instance-name".to_string(), inst_name);
     labels
@@ -27,7 +27,7 @@ mod tests {
         let labels = trait_labels("name".to_string(), "inst".to_string());
         assert_eq!(
             "trait".to_string(),
-            *labels.get("hydra.io/role").expect("role must be a string")
+            *labels.get("oam.dev/role").expect("role must be a string")
         );
         assert_eq!(
             "name".to_string(),

--- a/src/workload_type.rs
+++ b/src/workload_type.rs
@@ -14,22 +14,22 @@ pub use crate::workload_type::worker::{ReplicatedWorker, SingletonWorker};
 mod workload_builder;
 pub use crate::workload_type::workload_builder::WorkloadMetadata;
 
-pub const OAM_API_VERSION: &str = "core.hydra.io/v1alpha1";
+pub const OAM_API_VERSION: &str = "core.oam.dev/v1alpha1";
 
 /// Server is a replicable server
-pub const SERVER_NAME: &str = "core.hydra.io/v1alpha1.Server";
+pub const SERVER_NAME: &str = "core.oam.dev/v1alpha1.Server";
 /// SingletonServer is a kind of Server that can't be replicated
-pub const SINGLETON_SERVER_NAME: &str = "core.hydra.io/v1alpha1.SingletonServer";
+pub const SINGLETON_SERVER_NAME: &str = "core.oam.dev/v1alpha1.SingletonServer";
 
 /// SingletonTask is a task that cannot be replicated
-pub const SINGLETON_TASK_NAME: &str = "core.hydra.io/v1alpha1.SingletonTask";
+pub const SINGLETON_TASK_NAME: &str = "core.oam.dev/v1alpha1.SingletonTask";
 /// Task just means a replicated task which will replace ReplicatedTask
-pub const TASK_NAME: &str = "core.hydra.io/v1alpha1.Task";
+pub const TASK_NAME: &str = "core.oam.dev/v1alpha1.Task";
 
 /// Singleton worker is a Worker that cannot be replicated
-pub const SINGLETON_WORKER: &str = "core.hydra.io/v1alpha1.SingletonWorker";
+pub const SINGLETON_WORKER: &str = "core.oam.dev/v1alpha1.SingletonWorker";
 /// Worker is daemon process that does not listen on the network
-pub const WORKER_NAME: &str = "core.hydra.io/v1alpha1.Worker";
+pub const WORKER_NAME: &str = "core.oam.dev/v1alpha1.Worker";
 
 type InstigatorResult = Result<(), Error>;
 type StatusResult = Result<BTreeMap<String, String>, Error>;


### PR DESCRIPTION
MAJOR BREAKING CHANGE

This changes hydra.io to oam.dev, which breaks all of the currently installed apps.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>