### PR TITLE
validate worker config before starting a worker

### DIFF
--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -288,6 +288,7 @@ impl Instigator {
             match phase {
                 Phase::Add => {
                     info!("Adding component {}", component.name.clone());
+                    workload.validate()?;
                     trait_manager.exec(
                         self.namespace.as_str(),
                         self.client.clone(),
@@ -298,6 +299,7 @@ impl Instigator {
                 }
                 Phase::Modify => {
                     info!("Modifying component {}", component.name.clone());
+                    workload.validate()?;
                     trait_manager.exec(
                         self.namespace.as_str(),
                         self.client.clone(),

--- a/src/schematic/component.rs
+++ b/src/schematic/component.rs
@@ -398,6 +398,13 @@ pub struct Port {
     pub protocol: PortProtocol,
 }
 impl Port {
+    pub fn basic(name: String, container_port: i32) -> Self {
+        Port {
+            name,
+            container_port,
+            protocol: PortProtocol::TCP,
+        }
+    }
     fn to_container_port(&self) -> core::ContainerPort {
         core::ContainerPort {
             container_port: self.container_port,

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -14,6 +14,7 @@ use crate::workload_type::{server::to_config_maps, InstigatorResult, ParamMap};
 /// WorkloadMetadata contains common data about a workload.
 ///
 /// Individual workload types can embed this field.
+#[derive(Clone)]
 pub struct WorkloadMetadata {
     /// Name is the name of the release
     pub name: String,


### PR DESCRIPTION
This adds a new optional validation trait member for workload types, and implements the trait for the two worker types. Specifically, Rudr will throw an error if a worker tries to bind to a port, which is not allowed by the definition of `worker`.

Closes #323 

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>