### PR TITLE
bug(serviceaccount): install rudr in other namespaces

### DIFF
--- a/charts/rudr/templates/rolebinding.yaml
+++ b/charts/rudr/templates/rolebinding.yaml
@@ -31,7 +31,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ template "rudr.fullname" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ template "rudr.fullname" . }}


### PR DESCRIPTION
Use `.Release.Namespace` in `ClusterRoleBinding` to support installing `rudr`
in a namespace other than `default`.