### PR TITLE
docs: make helm3 installation easier for first time users

### DIFF
--- a/docs/tutorials/deploy_and_update.md
+++ b/docs/tutorials/deploy_and_update.md
@@ -22,7 +22,7 @@ my-cluster
 
 The fastest way to install Rudr is with Helm 3.
 
-> make sure your Helm 3 has version newer than `v3.0.0-beta.3`, or you have to install the CRDs with `kubectl apply -f charts/rudr/crds`
+> make sure your Helm 3 has version newer than `[v3.0.0-beta.3](https://github.com/helm/helm/releases/tag/v3.0.0-beta.3)`, or you have to install the CRDs with `kubectl apply -f charts/rudr/crds`
 
 ```console
 $ helm install rudr charts/rudr


### PR DESCRIPTION
Currently, it quite hard to find the helm3 installation guide as it is hidden under Github releases of helm/helm. This small change should make it easier for users to find helm3 binary and helm3 is stable we can remove it.