### PR TITLE
fix image tag in doc

### DIFF
--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -31,7 +31,7 @@ You will need both `kubectl` and `Helm 3` to install Rudr.
 1. Helm install Rudr
 
 ```console
-$ helm install rudr ./charts/rudr --wait --set image.tag=v0.8.0
+$ helm install rudr ./charts/rudr --wait --set image.tag=v1.0.0-alpha.1
 NAME: rudr
 LAST DEPLOYED: 2019-08-08 09:00:07.754179 -0600 MDT m=+0.710068733
 NAMESPACE: default


### PR DESCRIPTION
we don't have `0.8.0`, only `v1.0.0-alpha.1`

 https://cloud.docker.com/u/oamdev/repository/registry-1.docker.io/oamdev/rudr/tags