### PR TITLE
fix charts deployment to apps/v1

### DIFF
--- a/charts/healthscope/templates/deployment.yaml
+++ b/charts/healthscope/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "healthscope.fullname" . }}


### PR DESCRIPTION
fix the first issue of #393 `Error: apiVersion "apps/v1beta2" in healthscope/templates/deployment.yaml is not available  `