### PR TITLE
keep first-app-config without healthscope dependency

### DIFF
--- a/examples/first-app-config.yaml
+++ b/examples/first-app-config.yaml
@@ -20,5 +20,3 @@ spec:
               value: /
             - name: service_port
               value: 9999
-      applicationScopes:
-        - my-health-scope


### PR DESCRIPTION
I add health scope to `first-app-config`, but if user didn't install healthscope instance first, they will fail, so I remove the healthscope dependency from `first-app-config`.

We should add health-scope in another  example

fixes #431 