### PR TITLE
split build image into two nightly actions to reduce execute time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,8 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: Build Container Images
-        run: make docker-build-cx
+      - name: Build Container Images for amd64
+        run: make docker-build-amd64
+      - name: Build Container Images for arm64
+        run: make docker-build-arm64
       - name: Publish Container Images
         env:
           hydraoss_secret: ${{ secrets.hydraoss }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 REPO = oamdev/rudr
+HEALTHREPO = oamdev/healthscope
 TAG ?= latest
 ARCHS := amd64 arm64
 LOG_LEVEL := rudr=debug
@@ -27,11 +28,9 @@ test:
 run:
 	RUST_LOG="$(LOG_LEVEL)" RUST_BACKTRACE=short cargo run
 
+.PHONY: healthscoperun
 healthscoperun:
 	RUST_LOG="healthscope=debug" RUST_BACKTRACE=short cargo run --package healthscope
-
-healthscopebuild:
-	docker build -t oamdev/healthscope:latest --build-arg PACKAGE_NAME=healthscope .
 
 GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
 .PHONY: kind-e2e
@@ -51,24 +50,35 @@ kind-e2e:
 .PHONY: docker-build-cx
 docker-build-cx: $(addprefix docker-build-, $(ARCHS))
 
+.PHONY: docker-build-arm64
 docker-build-arm64:
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker build -t $(REPO)-arm64:$(TAG) --build-arg BUILDER_IMAGE=arm64v8/rust:1.38 --build-arg BASE_IMAGE=arm64v8/debian:stretch-slim .
+	docker build -t $(HEALTHREPO)-arm64:$(TAG) --build-arg BUILDER_IMAGE=arm64v8/rust:1.38 --build-arg BASE_IMAGE=arm64v8/debian:stretch-slim --build-arg PACKAGE_NAME=healthscope .
 
+.PHONY: docker-build-amd64
 docker-build-amd64:
 	docker build -t $(REPO)-amd64:$(TAG) --build-arg BUILDER_IMAGE=rust:1.38 --build-arg BASE_IMAGE=debian:stretch-slim .
+	docker build -t $(HEALTHREPO)-amd64:$(TAG) --build-arg BUILDER_IMAGE=rust:1.38 --build-arg BASE_IMAGE=debian:stretch-slim --build-arg PACKAGE_NAME=healthscope .
 
 .PHONY: docker-publish
 docker-publish: docker-build-cx
 	docker login -u hydraoss -p ${hydraoss_secret}
 	docker push $(REPO)-amd64:$(TAG)
+	docker push $(HEALTHREPO)-amd64:$(TAG)
 	docker push $(REPO)-arm64:$(TAG)
+	docker push $(HEALTHREPO)-arm64:$(TAG)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(REPO):$(TAG) $(REPO)-amd64:$(TAG) $(REPO)-arm64:$(TAG)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(REPO):$(TAG)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(HEALTHREPO):$(TAG) $(HEALTHREPO)-amd64:$(TAG) $(HEALTHREPO)-arm64:$(TAG)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(HEALTHREPO):$(TAG)
 
 # Temporary while we get the ARM64 build time sorted.
 .PHONY: docker-publish-amd64
 docker-publish-amd64:
 	docker push $(REPO)-amd64:$(TAG)
+	docker push $(HEALTHREPO)-amd64:$(TAG)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(REPO):$(TAG) $(REPO)-amd64:$(TAG)
 	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(REPO):$(TAG)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create $(HEALTHREPO):$(TAG) $(HEALTHREPO)-amd64:$(TAG)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push $(HEALTHREPO):$(TAG)


### PR DESCRIPTION
Now nightly build failed again cause it was running more than six hours. So I split them into two phases.

Also, I add health scope build into nightly GitHub action.