### PR TITLE
add k8s event record for rudr controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
 name = "rudr"
 version = "0.1.0"
 dependencies = [
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hyper = "0.12"
 clap = "~2.33"
 regex = "1.0"
 lazy_static = "1.4.0"
+chrono = { version = "0.4", features = ["serde"] }
 
 [workspace]
 members = [

--- a/src/kube_event.rs
+++ b/src/kube_event.rs
@@ -70,12 +70,8 @@ impl Event {
             type_: type_.to_string(),
             action: Some(info.action),
             eventTime: None,
-            firstTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
-                now.clone(),
-            )),
-            lastTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
-                now.clone(),
-            )),
+            firstTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(now)),
+            lastTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(now)),
             related: None,
             series: None,
             source: None,

--- a/src/kube_event.rs
+++ b/src/kube_event.rs
@@ -1,0 +1,136 @@
+use failure::Error;
+use k8s_openapi::api::core::v1::ObjectReference;
+use kube::{api::Api, api::PostParams, client::APIClient};
+use std::fmt;
+
+pub enum Type {
+    Normal,
+    Warning,
+}
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Type::Normal => write!(f, "Normal"),
+            Type::Warning => write!(f, "Warning"),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Event {
+    pub client: APIClient,
+    pub namespace: String,
+    pub reporting_component: Option<String>, // Name of the controller that emitted this Event,e.g. "oam.dev/rudr"
+    pub reporting_instance: Option<String>,  //ID of the controller instance
+    pub event_handle: Api<kube::api::v1Event>,
+}
+
+pub struct Info {
+    pub action: String,
+    pub message: String,
+    pub reason: String,
+}
+
+impl Event {
+    pub fn new(client: APIClient, namespace: String) -> Self {
+        Event {
+            client: client.clone(),
+            namespace: namespace.clone(),
+            reporting_component: None,
+            reporting_instance: None,
+            event_handle: Api::v1Event(client).within(namespace.as_str()),
+        }
+    }
+    fn make_event(
+        now: chrono::DateTime<chrono::Utc>,
+        namespace: String,
+        type_: Type,
+        info: Info,
+        involved_object: ObjectReference,
+        reporting_component: Option<String>,
+        reporting_instance: Option<String>,
+    ) -> kube::api::v1Event {
+        let name = format!(
+            "{}.{:x}",
+            involved_object.name.clone().unwrap(),
+            now.timestamp_nanos(),
+        );
+        kube::api::v1Event {
+            metadata: kube::api::ObjectMeta {
+                name,
+                namespace: Some(namespace.clone()),
+                ..Default::default()
+            },
+            involvedObject: involved_object,
+            reportingComponent: reporting_component.unwrap_or_else(|| "".to_string()),
+            reportingInstance: reporting_instance.unwrap_or_else(|| "".to_string()),
+            message: info.message,
+            reason: info.reason,
+            count: 1,
+            type_: type_.to_string(),
+            action: Some(info.action),
+            eventTime: None,
+            firstTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                now.clone(),
+            )),
+            lastTimestamp: Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                now.clone(),
+            )),
+            related: None,
+            series: None,
+            source: None,
+        }
+    }
+    pub fn push_event_message(
+        &self,
+        type_: Type,
+        info: Info,
+        involved_object: ObjectReference,
+    ) -> Result<(), Error> {
+        let now = chrono::Utc::now();
+        let event = Event::make_event(
+            now,
+            self.namespace.clone(),
+            type_,
+            info,
+            involved_object,
+            self.reporting_component.clone(),
+            self.reporting_instance.clone(),
+        );
+        self.event_handle
+            .create(&PostParams::default(), serde_json::to_vec(&event)?)?;
+        Ok(())
+    }
+}
+
+#[test]
+fn test_make_event() {
+    let now = chrono::Utc::now();
+    let ev = Event::make_event(
+        now,
+        "default".to_string(),
+        Type::Normal,
+        Info {
+            action: "ac".to_string(),
+            message: "ms".to_string(),
+            reason: "re".to_string(),
+        },
+        ObjectReference {
+            api_version: Some("core.oam.dev/v1alpha1".to_string()),
+            kind: None,
+            name: Some("test".to_string()),
+            field_path: None,
+            namespace: None,
+            resource_version: None,
+            uid: None,
+        },
+        None,
+        None,
+    );
+    assert_eq!(ev.count, 1);
+    assert_eq!(
+        ev.metadata.name,
+        format!("test.{:x}", now.timestamp_nanos())
+    );
+    assert_eq!(ev.action, Some("ac".to_string()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate lazy_static;
 extern crate regex;
 
 pub mod instigator;
+pub mod kube_event;
 pub mod lifecycle;
 pub mod schematic;
 mod trait_manager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn handle_event(
                     kube_event::Type::Warning,
                     kube_event::Info {
                         action: "create".to_string(),
-                        message: format!("creating AppConfig {} error", o.metadata.name.clone()),
+                        message: format!("create config {} error", o.metadata.name.clone()),
                         reason: format!("{}", err),
                     },
                     rudr::instigator::get_object_ref(o.clone()),
@@ -203,7 +203,7 @@ fn handle_event(
                     kube_event::Type::Warning,
                     kube_event::Info {
                         action: "update".to_string(),
-                        message: format!("updating AppConfig {} error", o.metadata.name.clone()),
+                        message: format!("update config {} error", o.metadata.name.clone()),
                         reason: format!("{}", err),
                     },
                     rudr::instigator::get_object_ref(o.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1beta1::{
 use rudr::instigator::{
     Instigator, COMPONENT_CRD, CONFIG_CRD, CONFIG_GROUP, CONFIG_VERSION, SCOPE_CRD, TRAIT_CRD,
 };
+use rudr::kube_event;
 use rudr::schematic::{
     component::Component, configuration::ApplicationConfiguration, OAMStatus, Status,
 };
@@ -26,8 +27,8 @@ fn kubeconfig() -> kube::Result<kube::config::Configuration> {
         Ok(_val) => {
             info!("Loading in-cluster config");
             incluster_config()
-        },
-        Err(_e) => load_kube_config()
+        }
+        Err(_e) => load_kube_config(),
     }
 }
 
@@ -179,8 +180,40 @@ fn handle_event(
 ) -> Result<(), Error> {
     let inst = Instigator::new(cli.clone(), namespace);
     match event {
-        WatchEvent::Added(o) => inst.add(o),
-        WatchEvent::Modified(o) => inst.modify(o),
+        WatchEvent::Added(o) => {
+            if let Err(err) = inst.add(o.clone()) {
+                if let Err(e) = inst.event_handler.push_event_message(
+                    kube_event::Type::Warning,
+                    kube_event::Info {
+                        action: "create".to_string(),
+                        message: format!("creating AppConfig {} error", o.metadata.name.clone()),
+                        reason: format!("{}", err),
+                    },
+                    rudr::instigator::get_object_ref(o.clone()),
+                ) {
+                    log::warn!("push event message for update err {}", e)
+                }
+                return Err(err);
+            }
+            Ok(())
+        }
+        WatchEvent::Modified(o) => {
+            if let Err(err) = inst.modify(o.clone()) {
+                if let Err(e) = inst.event_handler.push_event_message(
+                    kube_event::Type::Warning,
+                    kube_event::Info {
+                        action: "update".to_string(),
+                        message: format!("updating AppConfig {} error", o.metadata.name.clone()),
+                        reason: format!("{}", err),
+                    },
+                    rudr::instigator::get_object_ref(o.clone()),
+                ) {
+                    log::warn!("push event message for update err {}", e)
+                }
+                return Err(err);
+            }
+            Ok(())
+        }
         WatchEvent::Deleted(o) => inst.delete(o),
         WatchEvent::Error(ref e) => match e {
             ApiError { reason, .. } if reason == "AlreadyExists" => {


### PR DESCRIPTION
fixes #316 

This is a good start for rudr to add every important stage into kubenetes event. Then we could see the events from `kubectl describe` like below:

```
$ kubectl describe cfg first-app
Name:         first-app
Kind:         ApplicationConfiguration
...
Spec:
  Components:
    Component Name:  helloworld-python-v1
    Instance Name:   first-app-helloworld-python-v1
...
Events:
  Type     Reason                                                                                     Age   From  Message
  ----     ------                                                                                     ----  ----  -------
  Warning  ApiError NotFound ("componentschematics.core.oam.dev \"helloworld-python-v1\" not found")  3s          creating AppConfig first-app error
```

```
$ kubectl describe cfg first-app
Name:         first-app
Kind:         ApplicationConfiguration
..
Events:
  Type    Reason  Age   From  Message
  ----    ------  ----  ----  -------
  Normal          41s         component helloworld-python-v1 created
```