### PR TITLE
Avoid silent conversion of service_port in ingress trait & replicaCount in manualscaler trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Error> {
 
     let top_ns = std::env::var("KUBERNETES_NAMESPACE").unwrap_or_else(|_| DEFAULT_NAMESPACE.into());
     let top_cfg = kubeconfig().expect("Load default kubeconfig");
+    info!("apiserver:{}", top_cfg.base_path);
 
     // There is probably a better way to do this than to create two clones, but there is a potential
     // thread safety issue here.


### PR DESCRIPTION
Issue: #477

If the values are provided as string, try converting them,
else add warning to the log and set it to default value.

This may not be needed if we add the validate the config schema using validation schema which is in the works.