### PR TITLE
Removed redundant comma.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@
 </tr>
 <tr>
 <td><img alt="Application operator role" src="./media/app-operator-role.png" /></td>
-<td><b>Application operators</b> create instances of those components, assign them to <b>application configurations</b>, and designate their operational capabilities, and</td>,
+<td><b>Application operators</b> create instances of those components, assign them to <b>application configurations</b>, and designate their operational capabilities, and,</td>
 </tr>
 <tr>
 <td><img alt="Infrastructure operator role" src="./media/infra-operator-role.png" /></td>


### PR DESCRIPTION
Find out the redundant comma while reading the docs, and this PR is going to fix this:

![image](https://user-images.githubusercontent.com/3972545/70314545-a43bf880-1852-11ea-92c5-e9412930c576.png)

Thanks.
