### PR TITLE
Add reconciliation logic to get to the desired state for native K8s objects (deployment/svc/ing)

### DIFF
--- a/src/instigator.rs
+++ b/src/instigator.rs
@@ -142,13 +142,18 @@ impl Instigator {
             )?;
 
             let inst_name = component.instance_name.clone();
+            let owner_ref = self.component_instance_owner_reference(
+                component.component_name.clone(),
+                inst_name.clone(),
+            )?;
+            let new_owner_ref = Some(owner_ref);
 
             let workload_meta = self.get_workload_meta(
                 name.clone(),
                 inst_name.clone(),
                 &comp_def,
                 &params,
-                None,
+                new_owner_ref.clone(),
                 "StatusCheckLoop".to_string(),
             );
             // Instantiate components
@@ -177,7 +182,7 @@ impl Instigator {
                 instance_name: inst_name.clone(),
                 component: component.clone(),
                 parent_params: parent.clone(),
-                owner_ref: None,
+                owner_ref: new_owner_ref.clone(),
                 workload_type: comp_def.spec.workload_type.clone(),
                 traits: vec![], // Always starts empty.
                 component_schematic: comp_def.spec.clone(),

--- a/src/schematic/traits/ingress.rs
+++ b/src/schematic/traits/ingress.rs
@@ -154,6 +154,10 @@ impl TraitImplementation for Ingress {
         let ingress = match client.request::<ext::Ingress>(req) {
             Ok(ingress) => ingress,
             Err(e) => {
+                if e.to_string().contains("NotFound") {
+                    warn!("Ingress not found {}. Recreating ...", e.to_string());
+                    self.add(ns, client).unwrap_or(());
+                }
                 resource.insert(key.clone(), e.to_string());
                 return Some(resource);
             }

--- a/src/workload_type/server.rs
+++ b/src/workload_type/server.rs
@@ -8,6 +8,7 @@ use crate::workload_type::{
 
 use crate::workload_type::statefulset_builder::StatefulsetBuilder;
 use std::collections::BTreeMap;
+use log::{warn};
 
 /// A Replicated Server can take one component and scale it up or down.
 pub struct ReplicatedServer {
@@ -17,6 +18,21 @@ pub struct ReplicatedServer {
 impl ReplicatedServer {
     fn labels(&self) -> BTreeMap<String, String> {
         self.meta.labels("Service")
+    }
+    fn add_deployment_builder(&self) -> InstigatorResult {
+        DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
+            .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
+            .owner_ref(self.meta.owner_ref.clone())
+            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
+    }
+    fn add_service_builder(&self) -> InstigatorResult {
+        ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .labels(self.labels())
+            .select_labels(self.meta.select_labels())
+            .owner_ref(self.meta.owner_ref.clone())
+            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
     }
 }
 
@@ -54,19 +70,8 @@ impl WorkloadType for ReplicatedServer {
     fn add(&self) -> InstigatorResult {
         //pre create config_map
         self.meta.create_config_maps("Service")?;
-
-        DeploymentBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .parameter_map(self.meta.params.clone())
-            .labels(self.labels())
-            .annotations(self.meta.annotations.clone())
-            .owner_ref(self.meta.owner_ref.clone())
-            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;
-
-        ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .labels(self.labels())
-            .select_labels(self.meta.select_labels())
-            .owner_ref(self.meta.owner_ref.clone())
-            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
+        self.add_deployment_builder()?;
+        self.add_service_builder()
     }
     fn modify(&self) -> InstigatorResult {
         //TODO update config_map
@@ -108,12 +113,27 @@ impl WorkloadType for ReplicatedServer {
         let mut resources = BTreeMap::new();
 
         let key = "deployment/".to_string() + self.kube_name().as_str();
-        let state = self.meta.deployment_status()?;
+        let state = self.meta.deployment_status().unwrap_or_else(|e| {
+            if e.to_string().contains("NotFound") {
+                warn!("Deployment not found for instance_name:{} component_name:{}. Recreating it...", 
+                    self.meta.instance_name, self.meta.component_name);
+                self.add_deployment_builder().unwrap_or(());
+            }
+            e.to_string()
+        });
         resources.insert(key.clone(), state);
 
-        let svc_state = ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .get_status(self.meta.client.clone(), self.meta.namespace.clone());
         let svc_key = "service/".to_string() + self.kube_name().as_str();
+        let svc_status = ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .get_status(self.meta.client.clone(), self.meta.namespace.clone());
+        let svc_state = svc_status.unwrap_or_else( |e| {
+            if e.to_string().contains("NotFound") {
+                warn!("Service not found for instance_name:{} component_name:{}. Recreating it.", 
+                    self.meta.instance_name, self.meta.component_name);
+                self.add_service_builder().unwrap_or(());
+            }
+            e.to_string()
+            });
         resources.insert(svc_key.clone(), svc_state);
 
         Ok(resources)
@@ -130,6 +150,21 @@ impl SingletonServer {
     fn labels(&self) -> BTreeMap<String, String> {
         self.meta.labels("SingletonServer")
     }
+    fn add_statefulset_deployment_builder(&self) -> InstigatorResult {
+        StatefulsetBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .parameter_map(self.meta.params.clone())
+            .labels(self.labels())
+            .annotations(self.meta.annotations.clone())
+            .owner_ref(self.meta.owner_ref.clone())
+            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
+    }
+    fn add_service_builder(&self) -> InstigatorResult {
+        ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .labels(self.labels())
+            .select_labels(self.meta.select_labels())
+            .owner_ref(self.meta.owner_ref.clone())
+            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
+    }
 }
 
 impl KubeName for SingletonServer {
@@ -137,25 +172,17 @@ impl KubeName for SingletonServer {
         self.meta.instance_name.to_string()
     }
 }
+
 impl WorkloadType for SingletonServer {
     fn add(&self) -> InstigatorResult {
         //pre create config_map
         self.meta.create_config_maps("singleton-service")?;
 
         // Create deployment
-        StatefulsetBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .parameter_map(self.meta.params.clone())
-            .labels(self.labels())
-            .annotations(self.meta.annotations.clone())
-            .owner_ref(self.meta.owner_ref.clone())
-            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")?;
+        self.add_statefulset_deployment_builder()?;
 
         // Create service
-        ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .labels(self.labels())
-            .select_labels(self.meta.select_labels())
-            .owner_ref(self.meta.owner_ref.clone())
-            .do_request(self.meta.client.clone(), self.meta.namespace.clone(), "add")
+        self.add_service_builder()
     }
 
     //TODO: because pod upgrade have many restrictions and very complicated, so we don't support now.
@@ -184,12 +211,28 @@ impl WorkloadType for SingletonServer {
 
         let key = "statefulset/".to_string() + self.kube_name().as_str();
         let state = StatefulsetBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .status(self.meta.client.clone(), self.meta.namespace.clone())?;
+            .status(self.meta.client.clone(), self.meta.namespace.clone())
+            .unwrap_or_else(|e| {
+                if e.to_string().contains("NotFound") {
+                    warn!("Deployment not found for instance_name:{} component_name:{}. Recreating it...", 
+                        self.meta.instance_name, self.meta.component_name);
+                    self.add_statefulset_deployment_builder().unwrap_or(());
+                }
+                e.to_string()
+            });
         resources.insert(key.clone(), state);
 
-        let svc_state = ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
-            .get_status(self.meta.client.clone(), self.meta.namespace.clone());
         let svc_key = "service/".to_string() + self.kube_name().as_str();
+        let svc_state : String = ServiceBuilder::new(self.kube_name(), self.meta.definition.clone())
+            .get_status(self.meta.client.clone(), self.meta.namespace.clone())
+            .unwrap_or_else( |e| {
+                if e.to_string().contains("NotFound") {
+                    warn!("Statefulset not found for instance_name:{} component_name:{}. Recreating it.", 
+                        self.meta.instance_name, self.meta.component_name);
+                    self.add_service_builder().unwrap_or(());
+                }
+                e.to_string()
+            });
         resources.insert(svc_key.clone(), svc_state);
 
         Ok(resources)

--- a/src/workload_type/statefulset_builder.rs
+++ b/src/workload_type/statefulset_builder.rs
@@ -1,7 +1,6 @@
 use crate::schematic::component::Component;
 use crate::workload_type::workload_builder;
 use crate::workload_type::{InstigatorResult, ParamMap};
-use failure::Error;
 use k8s_openapi::api::apps::v1 as apps;
 use k8s_openapi::api::core::v1 as api;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as meta;
@@ -91,16 +90,14 @@ impl StatefulsetBuilder {
         }
     }
 
-    pub fn status(self, client: APIClient, namespace: String) -> Result<String, Error> {
+    pub fn status(self, client: APIClient, namespace: String) -> Result<String, kube::Error> {
         let sts: Object<_, apps::StatefulSetStatus> =
             match kube::api::Api::v1StatefulSet(client.clone())
                 .within(namespace.as_str())
                 .get_status(self.name.as_str())
             {
                 Ok(sts) => sts,
-                Err(e) => {
-                    return Ok(e.to_string());
-                }
+                Err(e) => return Err(e)
             };
         let status: apps::StatefulSetStatus = sts.status.unwrap();
         let replica = status.replicas;

--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -1,4 +1,3 @@
-use failure::Error;
 use k8s_openapi::api::apps::v1 as apps;
 use k8s_openapi::api::batch::v1 as batchapi;
 use k8s_openapi::api::core::v1 as api;
@@ -90,16 +89,14 @@ impl WorkloadMetadata {
         Ok(())
     }
 
-    pub fn deployment_status(&self) -> Result<String, Error> {
+    pub fn deployment_status(&self) -> Result<String, kube::Error> {
         let deploy: Object<_, apps::DeploymentStatus> =
             match kube::api::Api::v1Deployment(self.client.clone())
                 .within(self.namespace.as_str())
                 .get_status(self.kube_name().as_str())
             {
                 Ok(deploy) => deploy,
-                Err(e) => {
-                    return Ok(e.to_string());
-                }
+                Err(e) => return Err(e)
             };
         let status: apps::DeploymentStatus = deploy.status.unwrap();
         let replica = status.replicas.unwrap_or(0);
@@ -459,7 +456,7 @@ impl ServiceBuilder {
             })
         })
     }
-    pub fn get_status(self, client: APIClient, namespace: String) -> String {
+    pub fn get_status(self, client: APIClient, namespace: String) -> Result<String, kube::Error> {
         match kube::api::Api::v1Service(client)
             .within(namespace.as_str())
             .get_status(self.name.as_str())
@@ -467,11 +464,11 @@ impl ServiceBuilder {
             Ok(status) => {
                 let svc_status: Object<api::ServiceSpec, api::ServiceStatus> = status;
                 if let Some(_state) = svc_status.status {
-                    return "created".to_string();
+                    return Ok("created".to_string());
                 }
-                "not existed".to_string()
+                return Ok("not existed".to_string());
             }
-            Err(e) => e.to_string(),
+            Err(e) => return Err(e),
         }
     }
     pub fn do_request(self, client: APIClient, namespace: String, phase: &str) -> InstigatorResult {


### PR DESCRIPTION
https://github.com/oam-dev/rudr/issues/514

The issue was that rudr was not reconciling it's state with the latest status.
If a deployment/svc/ing is deleted when the application confgiuration still exists, runtime doesn't recreate them. It detects those objects are not found but no action was taken.

The fix here is to recreate those objects back. The recreated objects have correct owner reference so no objects are orphaned.