### PR TITLE
Oam status

### DIFF
--- a/src/workload_type/workload_builder.rs
+++ b/src/workload_type/workload_builder.rs
@@ -51,6 +51,10 @@ impl WorkloadMetadata {
             "oam.dev/instance-name".to_string(),
             self.instance_name.clone(),
         );
+        labels.insert(
+            "component.kubernetes.io".to_string(),
+            self.component_name.to_string(),
+        );
         labels
     }
     pub fn select_labels(&self) -> BTreeMap<String, String> {


### PR DESCRIPTION
adding failing pod's error messages to cfg's status field, as part of returned error messages back to the users



```
status:
  components:
    helloworld-python-v1:
      deployment/first-app-helloworld-python-v1: unavailable
      ingress/first-app-helloworld-python-v1-trait-ingress: created
      pod/first-app-helloworld-python-v1-f76cd96d6-grcrs: 'Reason: ImagePullBackOffmessage:
        Back-off pulling image "oamdev/helloworld-python:v2"'
      service/first-app-helloworld-python-v1: created
  phase: synced
```