### PR TITLE
Specifying that Rudr implements alpha 1 of the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![](https://github.com/oam-dev/rudr/workflows/Rust/badge.svg)
 
-Rudr is an [Open Application Model (OAM)](https://github.com/oam-dev/spec/blob/master/1.purpose_and_goals.md) implementation for Kubernetes. 
+Rudr is an implementation of the [Open Application Model (OAM) 1.0.0-alpha1](https://github.com/oam-dev/spec/releases/tag/v1.0.0-alpha.1) for Kubernetes. 
 
-***Note: Rudr is currently in alpha. It may reflect the API or features we are vetting before inclusion into the OAM spec.***
+***Note: Rudr is a reference implementation for the initial working draft of the OAM specification. It does not reflect the most recent version of the OAM specification.***
 
 ## Why Rudr?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Rudr documentation
 
-*Rudr* is the Kubernetes reference implementation of the [Open Application Model](https://github.com/oam-dev/spec) (OAM) specification, a team-centric standard for building cloud-native apps, where:
+*Rudr* is the Kubernetes reference implementation of the [Open Application Model (OAM) 1.0.0-alpha1](https://github.com/oam-dev/spec/releases/tag/v1.0.0-alpha.1) (OAM) specification, a team-centric standard for building cloud-native apps, where:
 
 <table border=0 rules=none>
 <tr>


### PR DESCRIPTION
Minor change in messaging to make it clear that Rudr currently implements release 1.0.0-alpha1 of the spec.