### PR TITLE
Adds TLS support for ingress trait.

### DIFF
--- a/charts/rudr/templates/traits.yaml
+++ b/charts/rudr/templates/traits.yaml
@@ -97,7 +97,15 @@ spec:
           "type": "string",
           "description": "Path to expose.",
           "default": "/"
-        }
+        },
+        "tls_hosts": {
+          "type": "string",
+          "description": "Host names for TLS certificate."
+        },
+        "tls_secret_name": {
+          "type": "string",
+          "description": "TLS's secret name in Kubernetes."
+        },
       }
     }
 


### PR DESCRIPTION
```
       traits:
         - name: ingress
           properties:
             hostname: example.com
             path: /
             servicePort: 9999
+            tlsHosts: example.com,www.example.com
+            tlsSecretName: mysecret
```


Closes issue #553 